### PR TITLE
Full SDK coverage: 15 new data sources + 1 resource + 2 bugfixes

### DIFF
--- a/docs/data-sources/accelerator_type.md
+++ b/docs/data-sources/accelerator_type.md
@@ -12,11 +12,74 @@ Provides information about available accelerator types (e.g. GPU models) that ca
 
 Use this data source to look up the ID of a GPU accelerator type by name. The returned ID can then be passed to the `accelerator_type_id` field of the `emma_vm` or `emma_spot_instance` resource.
 
+## How to Find Available Accelerator Types
+
+The provider does not currently have a data source that lists all accelerator types. To discover available GPU types, use the Emma API directly:
+
+```bash
+# 1. Get an access token
+TOKEN=$(curl -s -X POST 'https://api.emma.ms/external/v1/issue-token' \
+  -H 'Content-Type: application/json' \
+  -d '{"clientId":"YOUR_CLIENT_ID","clientSecret":"YOUR_CLIENT_SECRET"}' \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['accessToken'])")
+
+# 2. List all available accelerator types
+curl -s -H "Authorization: Bearer $TOKEN" \
+  'https://api.emma.ms/external/v1/accelerator-types' | python3 -m json.tool
+```
+
+Then use the `accelerator_type` name from the response in the data source lookup.
+
+### Available Accelerator Types
+
+| Name | Provider availability |
+|------|---------------------|
+| NVIDIA T4 | AWS |
+| NVIDIA A10 | Azure |
+| NVIDIA A10G | AWS |
+| NVIDIA A100 40 GB | AWS |
+| NVIDIA A100 80 GB | AWS |
+| NVIDIA L4 | AWS |
+| NVIDIA L40S | AWS |
+| NVIDIA H100 80 GB | AWS |
+| NVIDIA H100 94 GB | AWS |
+| NVIDIA H200 | AWS |
+| NVIDIA B200 Blackwell | AWS |
+| NVIDIA B200 Blackwell 180 GB | AWS |
+| NVIDIA Tesla V100 32 GB | Azure |
+| NVIDIA Tesla M60 | Azure |
+| NVIDIA RTX PRO 5000 48 GB | AWS |
+| NVIDIA RTX PRO 6000 | AWS |
+| AMD Instinct MI25 | Azure |
+| AMD Instinct MI300X | AWS |
+| AMD Radeon Pro V520 | Azure |
+| AMD Radeon Pro V710 | Azure |
+
+~> **Note:** Availability may vary by data center and change over time. Use the API call above to get the current list.
+
 ## Example Usage
+
+### Look up a single accelerator type
+
+```terraform
+data "emma_accelerator_type" "nvidia_t4" {
+  accelerator_type = "NVIDIA T4"
+}
+
+output "t4_id" {
+  value = data.emma_accelerator_type.nvidia_t4.id
+}
+
+output "t4_name" {
+  value = data.emma_accelerator_type.nvidia_t4.accelerator_type
+}
+```
+
+### Use with a GPU virtual machine
 
 ```terraform
 data "emma_accelerator_type" "nvidia_a100" {
-  accelerator_type = "NVIDIA A100"
+  accelerator_type = "NVIDIA A100 80 GB"
 }
 
 resource "emma_vm" "gpu_vm" {
@@ -29,9 +92,67 @@ resource "emma_vm" "gpu_vm" {
   ram_gb              = 32
   volume_type         = "ssd"
   volume_gb           = 100
+  security_group_id   = emma_security_group.security_group.id
   ssh_key_id          = emma_ssh_key.ssh_key.id
   accelerator_type_id = data.emma_accelerator_type.nvidia_a100.id
   accelerators        = 1
+}
+
+output "gpu_vm_id" {
+  value = emma_vm.gpu_vm.id
+}
+
+output "gpu_vm_status" {
+  value = emma_vm.gpu_vm.status
+}
+
+output "gpu_vm_accelerator_type_id" {
+  value = emma_vm.gpu_vm.accelerator_type_id
+}
+
+output "gpu_vm_accelerators" {
+  value = emma_vm.gpu_vm.accelerators
+}
+```
+
+### Use with a GPU spot instance
+
+```terraform
+data "emma_accelerator_type" "nvidia_t4" {
+  accelerator_type = "NVIDIA T4"
+}
+
+resource "emma_spot_instance" "gpu_spot" {
+  name                = "GPU-Spot"
+  data_center_id      = data.emma_data_center.aws.id
+  os_id               = data.emma_operating_system.ubuntu.id
+  cloud_network_type  = "isolated"
+  vcpu_type           = "hpc"
+  vcpu                = 4
+  ram_gb              = 16
+  volume_type         = "ssd"
+  volume_gb           = 64
+  security_group_id   = emma_security_group.security_group.id
+  ssh_key_id          = emma_ssh_key.ssh_key.id
+  price               = 0.15
+  accelerator_type_id = data.emma_accelerator_type.nvidia_t4.id
+  accelerators        = 1
+}
+
+output "gpu_spot_id" {
+  value = emma_spot_instance.gpu_spot.id
+}
+
+output "gpu_spot_status" {
+  value = emma_spot_instance.gpu_spot.status
+}
+
+output "gpu_spot_accelerator_type_id" {
+  value = emma_spot_instance.gpu_spot.accelerator_type_id
+}
+
+output "gpu_spot_accelerators" {
+  value = emma_spot_instance.gpu_spot.accelerators
 }
 ```
 
@@ -40,7 +161,7 @@ resource "emma_vm" "gpu_vm" {
 
 ### Required
 
-- `accelerator_type` (String) Name of the accelerator type (e.g. NVIDIA A100, NVIDIA T4, NVIDIA L4)
+- `accelerator_type` (String) Name of the accelerator type (e.g. NVIDIA A100 80 GB, NVIDIA T4, NVIDIA L4)
 
 ### Read-Only
 

--- a/docs/data-sources/accelerator_types.md
+++ b/docs/data-sources/accelerator_types.md
@@ -1,0 +1,47 @@
+---
+page_title: "emma_accelerator_types Data Source - emma"
+subcategory: ""
+description: |-
+  Returns a list of all available GPU accelerator types that can be used with compute instances.
+---
+
+# emma_accelerator_types (Data Source)
+
+Returns a list of all available GPU accelerator types. Use this data source to discover which GPU models are available on the platform before creating GPU-enabled virtual machines or spot instances.
+
+For looking up a specific accelerator type by name, use the [`emma_accelerator_type`](accelerator_type.md) data source instead.
+
+## Example Usage
+
+### List all available GPU types
+
+```terraform
+data "emma_accelerator_types" "all" {}
+
+output "available_gpus" {
+  value = data.emma_accelerator_types.all.accelerator_types
+}
+```
+
+### Use with vm_configurations to find GPU VMs
+
+```terraform
+data "emma_accelerator_types" "all" {}
+
+# Pick the first accelerator type and look up VM configs for it
+data "emma_vm_configurations" "gpu" {
+  accelerator_type_id = data.emma_accelerator_types.all.accelerator_types[0].id
+}
+
+output "gpu_types" {
+  value = [for t in data.emma_accelerator_types.all.accelerator_types : t.accelerator_type]
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `accelerator_types` (List of Object) List of available GPU accelerator types. Each element has:
+  - `id` (String) — Unique ID of the accelerator type (UUID)
+  - `accelerator_type` (String) — Name of the GPU model (e.g. "NVIDIA T4", "AMD Instinct MI25")

--- a/docs/data-sources/kuber_nodes_configs.md
+++ b/docs/data-sources/kuber_nodes_configs.md
@@ -1,0 +1,119 @@
+---
+page_title: "emma_kuber_nodes_configs Data Source - emma"
+subcategory: ""
+description: |-
+  Returns available hardware configurations for Kubernetes cluster worker nodes, filtered by connection type and optional hardware constraints.
+---
+
+# emma_kuber_nodes_configs (Data Source)
+
+Returns a list of available hardware configurations for Kubernetes cluster worker nodes in the Emma platform. Use this data source to discover valid node types, CPU/RAM/storage options, GPU configurations, and pricing before creating or scaling a Kubernetes cluster.
+
+`k8s_connection_type` is **required** — the API enforces it. All other filter attributes are optional.
+
+## Example Usage
+
+### List all public node configurations
+
+```terraform
+data "emma_kuber_nodes_configs" "public" {
+  k8s_connection_type = "public"
+}
+
+output "node_config_count" {
+  value = length(data.emma_kuber_nodes_configs.public.configurations)
+}
+```
+
+### Find GPU-enabled node configs for a private cluster
+
+```terraform
+data "emma_kuber_nodes_configs" "gpu_private" {
+  k8s_connection_type = "private"
+  accelerator_type_id = "aaf51e31-b8d2-42dd-af72-cf3b6ec49370"
+}
+
+output "gpu_node_options" {
+  value = [for c in data.emma_kuber_nodes_configs.gpu_private.configurations : {
+    provider    = c.provider_name
+    data_center = c.data_center_id
+    vcpu        = c.vcpu
+    ram_gb      = c.ram_gb
+    gpu_count   = c.accelerators
+    gpu_type    = c.accelerator_type
+    price       = c.price_per_unit
+  }]
+}
+```
+
+### Find budget node configs under a price cap
+
+```terraform
+data "emma_kuber_nodes_configs" "cheap" {
+  k8s_connection_type = "public"
+  vcpu_min            = 4
+  ram_gb_min          = 8
+  price_max           = 100
+}
+
+output "affordable_nodes" {
+  value = [for c in data.emma_kuber_nodes_configs.cheap.configurations : {
+    id       = c.id
+    provider = c.provider_name
+    vcpu     = c.vcpu
+    ram_gb   = c.ram_gb
+    price    = c.price_per_unit
+  }]
+}
+```
+
+## Schema
+
+### Required
+
+- `k8s_connection_type` (String) — Kubernetes cluster network connectivity type. The API requires this value. Use `"public"` or `"private"`.
+
+### Optional
+
+- `provider_id` (Number) — Filter by cloud provider ID.
+- `location_id` (Number) — Filter by geographic location ID.
+- `accelerator_type_id` (String) — Filter by GPU accelerator type ID. Use `emma_accelerator_types` to discover available IDs.
+- `accelerators_min` (Number) — Minimum quantity of GPU accelerators.
+- `accelerators_max` (Number) — Maximum quantity of GPU accelerators.
+- `data_center_id` (String) — Filter by data center ID (e.g. "aws-us-east-1").
+- `vcpu_type` (String) — Filter by vCPU type: "shared", "standard", or "hpc".
+- `vcpu_min` (Number) — Minimum number of vCPUs.
+- `vcpu_max` (Number) — Maximum number of vCPUs.
+- `ram_gb_min` (Number) — Minimum RAM in gigabytes.
+- `ram_gb_max` (Number) — Maximum RAM in gigabytes.
+- `volume_gb_min` (Number) — Minimum volume size in gigabytes.
+- `volume_gb_max` (Number) — Maximum volume size in gigabytes.
+- `volume_type` (String) — Filter by volume type (e.g. "ssd", "hdd").
+- `price_min` (Number) — Minimum price per unit.
+- `price_max` (Number) — Maximum price per unit.
+
+### Read-Only
+
+- `configurations` (List of Object) — List of matching Kubernetes node configurations. Each element has:
+  - `id` (String) — Configuration ID
+  - `provider_id` (Number) — ID of the cloud provider
+  - `provider_name` (String) — Name of the cloud provider (e.g. "AWS", "Azure")
+  - `location_id` (Number) — Location ID
+  - `location_name` (String) — Location name (city or region)
+  - `data_center_id` (String) — ID of the data center
+  - `data_center_name` (String) — Name of the data center
+  - `os_id` (Number) — ID of the operating system
+  - `os_type` (String) — Type of the operating system (e.g. "Ubuntu")
+  - `os_version` (String) — Version of the operating system (e.g. "22.04")
+  - `cloud_network_types` (List of String) — Supported cloud network types (e.g. ["default", "isolated"])
+  - `vcpu_type` (String) — vCPU type: "shared", "standard", or "hpc"
+  - `vcpu` (Number) — Number of virtual CPUs
+  - `ram_gb` (Number) — RAM in gigabytes
+  - `volume_gb` (Number) — Volume size in gigabytes
+  - `volume_type` (String) — Volume type (e.g. "ssd", "hdd")
+  - `accelerator_type_id` (String) — GPU accelerator type ID. Empty when no GPU is available.
+  - `accelerator_type` (String) — GPU accelerator type name (e.g. "NVIDIA T4"). Empty when no GPU is available.
+  - `accelerators` (Number) — Quantity of GPU accelerators. 0 when no GPU is available.
+  - `price_per_unit` (Number) — Price per billing unit for this configuration
+  - `price_currency` (String) — Currency of the price (e.g. "EUR")
+  - `price_unit` (String) — Billing period (e.g. "MONTHS")

--- a/docs/data-sources/kubernetes_clusters.md
+++ b/docs/data-sources/kubernetes_clusters.md
@@ -1,0 +1,76 @@
+---
+page_title: "emma_kubernetes_clusters Data Source - emma"
+subcategory: ""
+description: |-
+  Returns a list of Kubernetes clusters in the project, with optional filtering by project ID.
+---
+
+# emma_kubernetes_clusters (Data Source)
+
+Returns a list of Kubernetes clusters managed by the Emma platform. Use this data source to enumerate existing clusters, check their status and version, or reference cluster details when configuring workloads.
+
+All filter attributes are optional — omit `project_id` to return clusters across all projects your credentials can access.
+
+## Example Usage
+
+### List all Kubernetes clusters
+
+```terraform
+data "emma_kubernetes_clusters" "all" {}
+
+output "cluster_names" {
+  value = [for c in data.emma_kubernetes_clusters.all.kubernetes_clusters : c.name]
+}
+```
+
+### List clusters in a specific project
+
+```terraform
+data "emma_kubernetes_clusters" "project" {
+  project_id = 1297
+}
+
+output "active_clusters" {
+  value = [
+    for c in data.emma_kubernetes_clusters.project.kubernetes_clusters : c
+    if c.status == "active"
+  ]
+}
+```
+
+### Find clusters by connection type and Kubernetes version
+
+```terraform
+data "emma_kubernetes_clusters" "all" {}
+
+output "public_v128_clusters" {
+  value = [
+    for c in data.emma_kubernetes_clusters.all.kubernetes_clusters : c
+    if c.k8s_connection_type == "public" && startswith(c.version, "1.28")
+  ]
+}
+```
+
+## Schema
+
+### Optional
+
+- `project_id` (Number) — Filter Kubernetes clusters by project ID. Omit to return clusters across all accessible projects.
+
+### Read-Only
+
+- `kubernetes_clusters` (List of Object) — List of matching Kubernetes clusters. Each element has:
+  - `id` (Number) — Kubernetes cluster ID
+  - `name` (String) — Kubernetes cluster name
+  - `status` (String) — Status of the Kubernetes cluster (e.g. "active", "creating", "deleting")
+  - `control_plane_status` (String) — Control plane status (e.g. "running", "unavailable")
+  - `version` (String) — Kubernetes version (e.g. "1.28.5")
+  - `deployment_location` (String) — Deployment region of the Kubernetes cluster
+  - `k8s_connection_type` (String) — Kubernetes cluster network connectivity type (e.g. "public", "private")
+  - `domain_name` (String) — Domain name attached to the Kubernetes cluster
+  - `created_at` (String) — Date and time of cluster creation (ISO 8601)
+  - `created_by_name` (String) — Name of the user who created the cluster
+  - `created_by_id` (Number) — ID of the user who created the cluster
+  - `modified_at` (String) — Date and time when the cluster was last modified (ISO 8601)
+  - `modified_by_name` (String) — Name of the user who last modified the cluster
+  - `modified_by_id` (Number) — ID of the user who last modified the cluster

--- a/docs/data-sources/security_groups.md
+++ b/docs/data-sources/security_groups.md
@@ -1,0 +1,69 @@
+---
+page_title: "emma_security_groups Data Source - emma"
+subcategory: ""
+description: |-
+  Returns a list of security groups in the project, with optional filtering by project ID.
+---
+
+# emma_security_groups (Data Source)
+
+Returns a list of security groups defined in the Emma platform. Use this data source to look up security group IDs for attaching to compute instances, or to audit synchronization and recomposing status across providers.
+
+All filter attributes are optional — omit `project_id` to return security groups across all projects your credentials can access.
+
+## Example Usage
+
+### List all security groups
+
+```terraform
+data "emma_security_groups" "all" {}
+
+output "security_group_names" {
+  value = [for sg in data.emma_security_groups.all.security_groups : sg.name]
+}
+```
+
+### Find security groups in a specific project
+
+```terraform
+data "emma_security_groups" "project" {
+  project_id = 1297
+}
+
+output "synced_groups" {
+  value = [
+    for sg in data.emma_security_groups.project.security_groups : sg
+    if sg.synchronization_status == "synced"
+  ]
+}
+```
+
+### Resolve a security group ID by name for use in a VM resource
+
+```terraform
+data "emma_security_groups" "all" {}
+
+locals {
+  web_sg_id = one([
+    for sg in data.emma_security_groups.all.security_groups : sg.id
+    if sg.name == "web-tier"
+  ])
+}
+```
+
+## Schema
+
+### Optional
+
+- `project_id` (Number) — Filter security groups by project ID. Omit to return security groups across all accessible projects.
+
+### Read-Only
+
+- `security_groups` (List of Object) — List of matching security groups. Each element has:
+  - `id` (Number) — ID of the security group
+  - `name` (String) — Name of the security group
+  - `created_at` (String) — Date and time when the security group was created (ISO 8601)
+  - `created_by_name` (String) — Name of the user who created the security group
+  - `modified_at` (String) — Date and time when the security group was last modified (ISO 8601)
+  - `synchronization_status` (String) — Synchronization status of the security group rules across providers (e.g. "synced", "not_synced")
+  - `recomposing_status` (String) — Recomposing status of the security group when new compute instances are added (e.g. "done", "in_progress")

--- a/docs/data-sources/spot_configurations.md
+++ b/docs/data-sources/spot_configurations.md
@@ -1,0 +1,91 @@
+---
+page_title: "emma_spot_configurations Data Source - emma"
+subcategory: ""
+description: |-
+  Returns available spot instance configurations filtered by GPU type, provider, data center, hardware specs, and price.
+---
+
+# emma_spot_configurations (Data Source)
+
+Returns a list of available spot instance configurations. Use this data source to discover valid hardware configurations, pricing, and GPU availability before creating a spot instance.
+
+All filter attributes are optional — omit them to get all configurations, or combine them to narrow results.
+
+## Example Usage
+
+### Find GPU spot configurations
+
+```terraform
+data "emma_accelerator_type" "t4" {
+  accelerator_type = "NVIDIA T4"
+}
+
+data "emma_spot_configurations" "gpu_t4" {
+  accelerator_type_id = data.emma_accelerator_type.t4.id
+  vcpu_max            = 4
+}
+
+output "t4_spot_configs" {
+  value = [for c in data.emma_spot_configurations.gpu_t4.configurations : {
+    data_center = c.data_center_id
+    vcpu        = c.vcpu
+    ram_gb      = c.ram_gb
+    gpu         = c.accelerators
+    price       = c.price_per_unit
+  }]
+}
+```
+
+### Find cheapest spot instances
+
+```terraform
+data "emma_spot_configurations" "cheap" {
+  price_max  = 0.05
+  vcpu_min   = 2
+  ram_gb_min = 4
+}
+
+output "cheap_spots_count" {
+  value = length(data.emma_spot_configurations.cheap.configurations)
+}
+```
+
+## Schema
+
+### Optional
+
+- `accelerator_type_id` (String) Filter by GPU accelerator type ID. Use `emma_accelerator_types` or `emma_accelerator_type` data source to find the ID.
+- `data_center_id` (String) Filter by data center ID (e.g. "aws-sa-east-1", "azure-westeurope")
+- `provider_id` (Number) Filter by cloud provider ID (e.g. 255 = AWS, 256 = Azure)
+- `vcpu_type` (String) Filter by vCPU type: "shared", "standard", or "hpc"
+- `vcpu_min` (Number) Minimum number of vCPUs
+- `vcpu_max` (Number) Maximum number of vCPUs
+- `ram_gb_min` (Number) Minimum RAM in gigabytes
+- `ram_gb_max` (Number) Maximum RAM in gigabytes
+- `volume_gb_min` (Number) Minimum volume size in gigabytes
+- `volume_gb_max` (Number) Maximum volume size in gigabytes
+- `price_min` (Number) Minimum price per unit
+- `price_max` (Number) Maximum price per unit
+
+### Read-Only
+
+- `configurations` (List of Object) List of matching spot configurations. Each element has:
+  - `provider_id` (Number) — Cloud provider ID
+  - `provider_name` (String) — Cloud provider name (e.g. "AWS", "Azure")
+  - `location_name` (String) — Location name
+  - `data_center_id` (String) — Data center ID
+  - `data_center_name` (String) — Data center name
+  - `os_id` (Number) — Operating system ID
+  - `os_type` (String) — Operating system type (e.g. "Ubuntu")
+  - `cloud_network_types` (List of String) — Available network types
+  - `vcpu_type` (String) — vCPU type
+  - `vcpu` (Number) — Number of vCPUs
+  - `ram_gb` (Number) — RAM in gigabytes
+  - `volume_gb` (Number) — Volume size in gigabytes
+  - `volume_type` (String) — Volume type
+  - `accelerator_type_id` (String) — GPU accelerator type ID (empty if no GPU)
+  - `accelerator_type` (String) — GPU model name (empty if no GPU)
+  - `accelerators` (Number) — Number of GPU accelerators (0 if no GPU)
+  - `price_per_unit` (Number) — Spot price per hour
+  - `price_currency` (String) — Currency (e.g. "EUR")
+  - `price_unit` (String) — Billing period (e.g. "HOURS")

--- a/docs/data-sources/spots.md
+++ b/docs/data-sources/spots.md
@@ -1,0 +1,82 @@
+---
+page_title: "emma_spots Data Source - emma"
+subcategory: ""
+description: |-
+  Returns a list of spot instances in the project, with optional filtering by project ID.
+---
+
+# emma_spots (Data Source)
+
+Returns a list of spot instances running in the Emma platform. Use this data source to enumerate existing spot VMs, check their status and GPU type, or reference spot IDs in other resources.
+
+Spot instances are preemptible compute instances offered at reduced cost. This data source exposes the same placement and hardware details as `emma_vms`, plus the GPU accelerator type when applicable.
+
+All filter attributes are optional — omit `project_id` to return spot instances across all projects your credentials can access.
+
+## Example Usage
+
+### List all spot instances
+
+```terraform
+data "emma_spots" "all" {}
+
+output "spot_names" {
+  value = [for s in data.emma_spots.all.spots : s.name]
+}
+```
+
+### List GPU spot instances in a specific project
+
+```terraform
+data "emma_spots" "project" {
+  project_id = 1297
+}
+
+output "gpu_spots" {
+  value = [
+    for s in data.emma_spots.project.spots : s
+    if s.accelerator_type != null && s.accelerator_type != ""
+  ]
+}
+```
+
+### Find all active spots on a given provider
+
+```terraform
+data "emma_spots" "all" {}
+
+output "aws_active_spots" {
+  value = [
+    for s in data.emma_spots.all.spots : s
+    if s.provider_name == "AWS" && s.status == "active"
+  ]
+}
+```
+
+## Schema
+
+### Optional
+
+- `project_id` (Number) — Filter spot instances by project ID. Omit to return spot instances across all accessible projects.
+
+### Read-Only
+
+- `spots` (List of Object) — List of matching spot instances. Each element has:
+  - `id` (Number) — ID of the spot instance
+  - `name` (String) — Name of the spot instance
+  - `status` (String) — Current status of the spot instance (e.g. "active", "poweredOff")
+  - `project_id` (Number) — Project ID the spot instance belongs to
+  - `provider_id` (Number) — ID of the cloud provider
+  - `provider_name` (String) — Name of the cloud provider (e.g. "AWS", "Azure")
+  - `location_id` (Number) — ID of the geographic location
+  - `location_name` (String) — Name of the geographic location
+  - `data_center_id` (String) — ID of the data center (e.g. "aws-us-east-1")
+  - `data_center_name` (String) — Name of the data center
+  - `os_id` (Number) — ID of the operating system
+  - `os_type` (String) — Type of the operating system (e.g. "Ubuntu")
+  - `vcpu` (Number) — Number of virtual CPUs
+  - `vcpu_type` (String) — vCPU type: "shared", "standard", or "hpc"
+  - `ram_gb` (Number) — RAM in gigabytes
+  - `cloud_network_type` (String) — Cloud network type of the spot instance (e.g. "default", "isolated", "multi-cloud")
+  - `accelerator_type` (String) — GPU accelerator type name (e.g. "NVIDIA T4"). Empty string when no GPU is attached.
+  - `created_at` (String) — Date and time when the spot instance was created (ISO 8601)

--- a/docs/data-sources/ssh_key.md
+++ b/docs/data-sources/ssh_key.md
@@ -1,0 +1,51 @@
+---
+page_title: "emma_ssh_key Data Source - emma"
+subcategory: ""
+description: |-
+  Provides information about an existing SSH key by its ID.
+---
+
+# emma_ssh_key (Data Source)
+
+Provides information about an existing SSH key by its ID.
+
+Use this data source to look up an SSH key that already exists in Emma — for example, to wire its `id` into an `emma_vm` resource without importing the key into Terraform state.
+
+To create a new SSH key and manage it as Terraform-owned infrastructure, use the [`emma_ssh_key` resource](../resources/ssh_key.md) instead.
+
+## Example Usage
+
+```terraform
+data "emma_ssh_key" "shared" {
+  id = 42
+}
+
+resource "emma_vm" "web" {
+  name               = "web-server"
+  data_center_id     = data.emma_data_center.aws.id
+  os_id              = data.emma_operating_system.ubuntu.id
+  cloud_network_type = "multi-cloud"
+  vcpu_type          = "shared"
+  vcpu               = 2
+  ram_gb             = 4
+  volume_type        = "ssd"
+  volume_gb          = 40
+  ssh_key_id         = data.emma_ssh_key.shared.id
+}
+```
+
+## Schema
+
+### Required
+
+- `id` (Number) — ID of the SSH key to look up.
+
+### Read-Only
+
+- `name` (String) — SSH key name.
+- `key` (String) — SSH public key content.
+- `key_type` (String) — SSH key type: `RSA` or `ED25519`.
+- `fingerprint` (String) — SSH key fingerprint.
+- `created_at` (String) — Date and time when the SSH key was created (ISO 8601).
+- `created_by_name` (String) — Name of the user who created the SSH key.
+- `created_by_id` (Number) — ID of the user who created the SSH key.

--- a/docs/data-sources/ssh_keys.md
+++ b/docs/data-sources/ssh_keys.md
@@ -1,0 +1,75 @@
+---
+page_title: "emma_ssh_keys Data Source - emma"
+subcategory: ""
+description: |-
+  Returns a list of all SSH keys in the project.
+---
+
+# emma_ssh_keys (Data Source)
+
+Returns a list of all SSH keys stored in the Emma platform. Use this data source to look up SSH key IDs for assigning to compute instances, or to verify which keys are available before creating a VM.
+
+The full public key content is included in the `key` field, which is useful for cross-referencing keys against your local `~/.ssh` directory or for auditing team access.
+
+This data source returns all SSH keys accessible to your credentials and does not accept filter arguments.
+
+## Example Usage
+
+### List all SSH key names and fingerprints
+
+```terraform
+data "emma_ssh_keys" "all" {}
+
+output "key_inventory" {
+  value = [for k in data.emma_ssh_keys.all.ssh_keys : {
+    name        = k.name
+    fingerprint = k.fingerprint
+    type        = k.key_type
+  }]
+}
+```
+
+### Resolve an SSH key ID by name for use in a VM resource
+
+```terraform
+data "emma_ssh_keys" "all" {}
+
+locals {
+  deploy_key_id = one([
+    for k in data.emma_ssh_keys.all.ssh_keys : k.id
+    if k.name == "ci-deploy"
+  ])
+}
+
+resource "emma_vm" "web" {
+  # ...
+  ssh_key_id = local.deploy_key_id
+}
+```
+
+### Find all ED25519 keys created by a specific user
+
+```terraform
+data "emma_ssh_keys" "all" {}
+
+output "ed25519_keys" {
+  value = [
+    for k in data.emma_ssh_keys.all.ssh_keys : k
+    if k.key_type == "ED25519" && k.created_by_name == "a.prihodko"
+  ]
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `ssh_keys` (List of Object) — List of all accessible SSH keys. Each element has:
+  - `id` (Number) — SSH key ID
+  - `name` (String) — SSH key name
+  - `key` (String) — Full SSH public key content (e.g. "ssh-rsa AAAA...")
+  - `key_type` (String) — SSH key algorithm: "RSA" or "ED25519"
+  - `fingerprint` (String) — SHA-256 fingerprint of the public key
+  - `created_at` (String) — Date and time when the SSH key was created (ISO 8601)
+  - `created_by_name` (String) — Name of the user who created the SSH key
+  - `created_by_id` (Number) — ID of the user who created the SSH key

--- a/docs/data-sources/statistical_data.md
+++ b/docs/data-sources/statistical_data.md
@@ -1,0 +1,379 @@
+---
+page_title: "emma_statistical_data Data Source - emma"
+subcategory: ""
+description: |-
+  Fetches statistical data from emma's DWH. Exactly one query block must be configured. The corresponding result list attribute will be populated in state.
+---
+
+# emma_statistical_data (Data Source)
+
+!> **Deprecated** The underlying API endpoint `POST /v1/statistics/retrieve` was marked deprecated on **2026-05-13**. This data source remains available for historical reporting until a replacement endpoint is provided. Do not build new integrations against it.
+
+Fetches statistical data from Emma's data warehouse. The data source implements a discriminated-union query model: configure **exactly one** of the ten query blocks below. The provider will return a validation error if zero or more than one block is set.
+
+Only the result list attribute that corresponds to the configured query block will be populated — all other `*_results` attributes will be empty lists.
+
+## Query Variants
+
+| Query block | Result attribute | Use case |
+|---|---|---|
+| `project_summary` | `project_summary_results` | Cost + installation count per service for the whole project |
+| `resource_analysis` | `resource_analysis_results` | CPU / RAM / disk time-series over a custom date range |
+| `vm_analytics` | `vm_analytics_results` | Aggregated utilization analytics for a single VM |
+| `vm_monitoring` | `vm_monitoring_results` | Time-series monitoring data for a single VM |
+| `product_statistics` | `product_statistics_results` | Per-VM cost and resource statistics, filterable by service |
+| `kubernetes_cluster_objects` | `kubernetes_cluster_objects_results` | Inventory of Kubernetes objects in a cluster |
+| `kubernetes_cluster_metrics` | `kubernetes_cluster_metrics_results` | Available metric definitions for a cluster |
+| `kubernetes_cluster_object_states` | `kubernetes_cluster_object_states_results` | Object state distributions in a cluster |
+| `kubernetes_cluster_current_state` | `kubernetes_cluster_current_state_results` | Current-state metric values for cluster objects |
+| `kubernetes_cluster_changing_metrics` | `kubernetes_cluster_changing_metrics_results` | Time-series changing metrics for cluster objects |
+
+## Example Usage
+
+### Project cost summary
+
+```terraform
+data "emma_statistical_data" "summary" {
+  project_summary = {
+    dataset_name = "project_summary"
+  }
+}
+
+output "service_costs" {
+  value = [for r in data.emma_statistical_data.summary.project_summary_results : {
+    service           = r.service
+    cost              = r.cost
+    all_installations = r.all_installations
+  }]
+}
+```
+
+### VM analytics for a specific VM
+
+```terraform
+data "emma_statistical_data" "vm_stats" {
+  vm_analytics = {
+    dataset_name = "vm_analytics"
+    vm_id        = 12345
+  }
+}
+
+output "cpu_utilization" {
+  value = [for r in data.emma_statistical_data.vm_stats.vm_analytics_results : {
+    timecode                       = r.timecode
+    cpu_utilization_average_cores  = r.cpu_utilization_average_cores
+    ram_usage_average_mb           = r.ram_usage_average_mb
+  }]
+}
+```
+
+### Resource analysis over a date range
+
+```terraform
+data "emma_statistical_data" "resource_trend" {
+  resource_analysis = {
+    dataset_name = "resource_analysis"
+    filters = {
+      period_start = "2026-01-01T00:00:00Z"
+      period_end   = "2026-03-31T23:59:59Z"
+    }
+  }
+}
+
+output "resource_trend" {
+  value = data.emma_statistical_data.resource_trend.resource_analysis_results
+}
+```
+
+## Schema
+
+### Query Input Blocks (Optional — exactly one must be set)
+
+#### `project_summary`
+
+- `dataset_name` (String, Required) — Dataset name identifier.
+
+#### `resource_analysis`
+
+- `dataset_name` (String, Required) — Dataset name identifier.
+- `filters` (Required):
+  - `period_start` (String, Required) — Start of the analysis period (ISO 8601).
+  - `period_end` (String, Required) — End of the analysis period (ISO 8601).
+
+#### `vm_analytics`
+
+- `dataset_name` (String, Required) — Dataset name identifier.
+- `vm_id` (Number, Required) — ID of the virtual machine.
+
+#### `vm_monitoring`
+
+- `dataset_name` (String, Required) — Dataset name identifier.
+- `vm_id` (Number, Required) — ID of the virtual machine.
+- `filters` (Required):
+  - `period` (String, Required) — Monitoring period (e.g. `1h`, `24h`, `7d`).
+
+#### `product_statistics`
+
+- `dataset_name` (String, Required) — Dataset name identifier.
+- `filters` (Required):
+  - `service_filter` (String, Required) — Service name filter.
+
+#### `kubernetes_cluster_objects`
+
+- `dataset_name` (String, Required) — Dataset name identifier.
+- `core_cluster_id` (Number, Required) — Core cluster ID.
+
+#### `kubernetes_cluster_metrics`
+
+- `dataset_name` (String, Required) — Dataset name identifier.
+- `core_cluster_id` (Number, Required) — Core cluster ID.
+- `filters` (Required):
+  - `object_type` (String, Required) — Object type to filter.
+  - `object_name` (String, Required) — Object name to filter.
+  - `breakdown_level` (String, Required) — Breakdown level.
+
+#### `kubernetes_cluster_object_states`
+
+- `dataset_name` (String, Required) — Dataset name identifier.
+- `core_cluster_id` (Number, Required) — Core cluster ID.
+- `filters` (Required):
+  - `object_type` (String, Required) — Object type to filter.
+  - `object_name` (String, Required) — Object name to filter.
+  - `breakdown_level` (String, Required) — Breakdown level.
+  - `object_states_metrics` (List of String, Required) — List of object state metric names.
+
+#### `kubernetes_cluster_current_state`
+
+- `dataset_name` (String, Required) — Dataset name identifier.
+- `core_cluster_id` (Number, Required) — Core cluster ID.
+- `filters` (Required):
+  - `object_type` (String, Required) — Object type to filter.
+  - `object_name` (String, Required) — Object name to filter.
+  - `breakdown_level` (String, Required) — Breakdown level.
+  - `current_state_metrics` (List of String, Required) — List of current state metric names.
+  - `custom_filter_state` (String, Required) — Custom filter state.
+  - `custom_filter_avg_cpu_rule` (String, Optional) — Custom CPU filter rule (nullable).
+  - `custom_filter_avg_cpu_value` (Number, Required) — Custom CPU filter value.
+  - `custom_filter_avg_memory_rule` (String, Required) — Custom memory filter rule.
+  - `custom_filter_avg_memory_value` (Number, Required) — Custom memory filter value.
+  - `custom_filter_avg_storage_rule` (String, Required) — Custom storage filter rule.
+  - `custom_filter_avg_storage_value` (Number, Required) — Custom storage filter value.
+  - `custom_filter_subobjects` (List of String, Required) — List of subobjects to filter.
+
+#### `kubernetes_cluster_changing_metrics`
+
+- `dataset_name` (String, Required) — Dataset name identifier.
+- `core_cluster_id` (Number, Required) — Core cluster ID.
+- `filters` (Required):
+  - `object_type` (String, Required) — Object type to filter.
+  - `object_name` (String, Required) — Object name to filter.
+  - `breakdown_level` (String, Required) — Breakdown level.
+  - `changing_metrics` (List of String, Required) — List of changing metric names.
+  - `timespan` (String, Required) — Timespan for the query.
+  - `custom_filter_state` (String, Required) — Custom filter state.
+  - `custom_filter_avg_cpu_rule` (String, Optional) — Custom CPU filter rule (nullable).
+  - `custom_filter_avg_cpu_value` (Number, Required) — Custom CPU filter value.
+  - `custom_filter_avg_memory_rule` (String, Required) — Custom memory filter rule.
+  - `custom_filter_avg_memory_value` (Number, Required) — Custom memory filter value.
+  - `custom_filter_avg_storage_rule` (String, Required) — Custom storage filter rule.
+  - `custom_filter_avg_storage_value` (Number, Required) — Custom storage filter value.
+  - `custom_filter_subobjects` (List of String, Required) — List of subobjects to filter.
+
+---
+
+### Read-Only Result Attributes
+
+Only the result list matching the configured query block will be non-empty.
+
+#### `project_summary_results` (List of Object)
+
+- `service` (String) — Service name.
+- `all_installations` (Number) — Total number of installations.
+- `cost` (Number) — Total cost.
+
+#### `resource_analysis_results` (List of Object)
+
+- `service` (String) — Service name.
+- `timecode` (String) — Time code.
+- `cpu_cores_number` (Number) — Number of CPU cores.
+- `ram_total_amount_gb` (Number) — Total RAM in GB.
+- `disk_space_total_gb` (Number) — Total disk space in GB.
+- `type` (String) — Resource type.
+
+#### `vm_analytics_results` (List of Object)
+
+- `vm_id` (Number) — VM ID.
+- `timecode` (String) — Time code.
+- `avg_date_start` (String) — Average period start date.
+- `avg_date_end` (String) — Average period end date.
+- `quantiles_date_start` (String) — Quantiles period start date.
+- `quantiles_date_end` (String) — Quantiles period end date.
+- `cpu_data_present` (Number) — CPU data present flag.
+- `cpu_utilization_average_cores` (Number) — Average CPU utilization in cores.
+- `cpu_cores_number` (Number) — Total CPU cores.
+- `cpu_total_percent` (Number) — CPU total percent.
+- `cpu_human_label` (String) — Human-readable CPU label.
+- `ram_data_present` (Number) — RAM data present flag.
+- `ram_usage_average_mb` (Number) — Average RAM usage in MB.
+- `ram_total_amount_mb` (Number) — Total RAM in MB.
+- `ram_human_label` (String) — Human-readable RAM label.
+- `disk_used_data_present` (Number) — Disk used data present flag.
+- `disk_space_used_gb` (Number) — Disk space used in GB.
+- `disk_space_total_gb` (Number) — Total disk space in GB.
+- `disk_space_human_label` (String) — Human-readable disk label.
+- `disk_write_data_present` (Number) — Disk write data present flag.
+- `disk_write_bps` (Number) — Disk write speed in bytes/s.
+- `disk_write_human` (Number) — Disk write human value.
+- `disk_write_human_label` (String) — Human-readable disk write label.
+- `disk_read_data_present` (Number) — Disk read data present flag.
+- `disk_read_bps` (Number) — Disk read speed in bytes/s.
+- `disk_read_human` (Number) — Disk read human value.
+- `disk_read_human_label` (String) — Human-readable disk read label.
+- `network_out_data_present` (Number) — Network out data present flag.
+- `network_out_bps` (Number) — Network out speed in bytes/s.
+- `network_out_human` (Number) — Network out human value.
+- `network_out_human_label` (String) — Human-readable network out label.
+- `network_in_data_present` (Number) — Network in data present flag.
+- `network_in_bps` (Number) — Network in speed in bytes/s.
+- `network_in_human` (Number) — Network in human value.
+- `network_in_human_label` (String) — Human-readable network in label.
+- `gpu_data_present` (Number) — GPU data present flag.
+- `gpu_utilization_avg_percent` (Number) — Average GPU utilization percent.
+- `gpu_total_percent` (Number) — GPU total percent.
+- `gpu_human_label` (String) — Human-readable GPU label.
+- `gpu_ram_data_present` (Number) — GPU RAM data present flag.
+- `gpu_ram_usage_avg_gb` (Number) — Average GPU RAM usage in GB.
+- `gpu_ram_total_gb` (Number) — Total GPU RAM in GB.
+- `gpu_ram_human_label` (String) — Human-readable GPU RAM label.
+- `gpu_ram_utilization_data_present` (Number) — GPU RAM utilization data present flag.
+- `gpu_ram_utilization_avg_percent` (Number) — Average GPU RAM utilization percent.
+- `gpu_ram_utilization_total_percent` (Number) — GPU RAM utilization total percent.
+- `gpu_ram_utilization_human_label` (String) — Human-readable GPU RAM utilization label.
+- `is_shown_short` (Number) — Is shown short flag.
+- `type` (String) — Record type.
+
+#### `vm_monitoring_results` (List of Object)
+
+- `timecode` (String) — Time code.
+- `cpu_data_present` (Number) — CPU data present flag.
+- `cpu_utilization_average_cores` (Number) — Average CPU utilization in cores.
+- `avg_cpu_utilization_average_cores` (Number) — Period average CPU utilization in cores.
+- `max_cpu_utilization_average_cores` (Number) — Period max CPU utilization in cores.
+- `cpu_total_percent` (Number) — CPU total percent.
+- `cpu_human_label` (String) — Human-readable CPU label.
+- `ram_data_present` (Number) — RAM data present flag.
+- `ram_usage_average_gb` (Number) — Average RAM usage in GB.
+- `avg_ram_usage_average_gb` (Number) — Period average RAM usage in GB.
+- `max_ram_usage_average_gb` (Number) — Period max RAM usage in GB.
+- `ram_total_amount_gb` (Number) — Total RAM in GB.
+- `ram_human_label` (String) — Human-readable RAM label.
+- `disk_used_data_present` (Number) — Disk used data present flag.
+- `disk_space_used_gb` (Number) — Disk space used in GB.
+- `avg_disk_space_used_gb` (Number) — Period average disk space used in GB.
+- `max_disk_space_used_gb` (Number) — Period max disk space used in GB.
+- `disk_space_total_gb` (Number) — Total disk space in GB.
+- `disk_space_human_label` (String) — Human-readable disk label.
+- `disk_write_data_present` (Number) — Disk write data present flag.
+- `disk_write_coef` (Number) — Disk write coefficient.
+- `disk_write_human` (Number) — Disk write human value.
+- `avg_disk_write_human` (Number) — Period average disk write human value.
+- `max_disk_write_human` (Number) — Period max disk write human value.
+- `disk_write_human_label` (String) — Human-readable disk write label.
+- `disk_read_data_present` (Number) — Disk read data present flag.
+- `disk_read_coef` (Number) — Disk read coefficient.
+- `disk_read_human` (Number) — Disk read human value.
+- `avg_disk_read_human` (Number) — Period average disk read human value.
+- `max_disk_read_human` (Number) — Period max disk read human value.
+- `disk_read_human_label` (String) — Human-readable disk read label.
+- `network_out_data_present` (Number) — Network out data present flag.
+- `network_out_coef` (Number) — Network out coefficient.
+- `network_out_human` (Number) — Network out human value.
+- `avg_network_out_human` (Number) — Period average network out human value.
+- `max_network_out_human` (Number) — Period max network out human value.
+- `network_out_human_label` (String) — Human-readable network out label.
+- `network_in_data_present` (Number) — Network in data present flag.
+- `network_in_coef` (Number) — Network in coefficient.
+- `network_in_human` (Number) — Network in human value.
+- `avg_network_in_human` (Number) — Period average network in human value.
+- `max_network_in_human` (Number) — Period max network in human value.
+- `network_in_human_label` (String) — Human-readable network in label.
+- `gpu_ram_usage_data_present` (Number) — GPU RAM usage data present flag.
+- `gpu_ram_usage_avg_gb` (Number) — Average GPU RAM usage in GB.
+- `avg_gpu_ram_usage_avg_gb` (Number) — Period average GPU RAM usage in GB.
+- `max_gpu_ram_usage_avg_gb` (Number) — Period max GPU RAM usage in GB.
+- `gpu_ram_usage_human_label` (String) — Human-readable GPU RAM usage label.
+- `gpu_ram_utilization_avg_present` (Number) — GPU RAM utilization avg present flag.
+- `gpu_ram_utilization_avg_percent` (Number) — Average GPU RAM utilization percent.
+- `avg_gpu_ram_utilization_avg_percent` (Number) — Period average GPU RAM utilization percent.
+- `max_gpu_ram_utilization_avg_percent` (Number) — Period max GPU RAM utilization percent.
+- `gpu_ram_utilization_human_label` (String) — Human-readable GPU RAM utilization label.
+- `gpu_utilization_data_present` (Number) — GPU utilization data present flag.
+- `gpu_utilization_avg_percent` (Number) — Average GPU utilization percent.
+- `avg_gpu_utilization_avg_percent` (Number) — Period average GPU utilization percent.
+- `max_gpu_utilization_avg_percent` (Number) — Period max GPU utilization percent.
+- `gpu_utilization_human_label` (String) — Human-readable GPU utilization label.
+
+#### `product_statistics_results` (List of Object)
+
+- `service` (String) — Service name.
+- `vm_id` (Number) — VM ID.
+- `vm_name` (String) — VM name.
+- `head_product_id` (Number) — Head product ID.
+- `head_product_name` (String) — Head product name.
+- `currency` (String) — Cost currency.
+- `cost` (Number) — Cost value.
+- `provider_name` (String) — Cloud provider name.
+- `country` (String) — Country.
+- `location` (String) — Location.
+- `latitude` (Number) — Geographic latitude.
+- `longitude` (Number) — Geographic longitude.
+- `status_normalized` (String) — Normalized status.
+- `cpu_total` (Number) — Total CPU.
+- `ram_total` (Number) — Total RAM.
+- `disk_usage_total` (Number) — Total disk usage.
+- `cpu_usage` (Number) — CPU usage.
+- `ram_usage` (Number) — RAM usage.
+- `disk_usage` (Number) — Disk usage.
+- `empty_value` (Number) — Empty value placeholder.
+
+#### `kubernetes_cluster_objects_results` (List of Object)
+
+- `object_type` (String) — Type of the Kubernetes object.
+- `object_name` (String) — Name of the Kubernetes object.
+
+#### `kubernetes_cluster_metrics_results` (List of Object)
+
+- `metric_name` (String) — Metric name.
+- `ui_metric_group` (String) — UI metric group.
+- `ui_metric_name` (String) — UI display name for the metric.
+- `block_name` (String) — UI block name.
+
+#### `kubernetes_cluster_object_states_results` (List of Object)
+
+- `metric_name` (String) — Metric name.
+- `ui_metric_group` (String) — UI metric group.
+- `ui_color_group_id` (List of Number) — UI color group IDs.
+- `ui_metric_name` (String) — UI display name for the metric.
+- `subobject_name` (String) — Subobject name.
+- `value` (List of String) — State values.
+
+#### `kubernetes_cluster_current_state_results` (List of Object)
+
+- `subobject_name` (String) — Subobject name.
+- `metric_name` (String) — Metric name.
+- `ui_metric_group` (String) — UI metric group.
+- `ui_color_group_id` (Number) — UI color group ID.
+- `ui_metric_name` (String) — UI display name for the metric.
+- `value` (Number) — Current state metric value.
+
+#### `kubernetes_cluster_changing_metrics_results` (List of Object)
+
+- `subobject_name` (String) — Subobject name.
+- `metric_name` (String) — Metric name.
+- `ui_metric_group` (String) — UI metric group.
+- `ui_color_group_id` (Number) — UI color group ID.
+- `ui_metric_name` (String) — UI display name for the metric.
+- `human_label` (String) — Human-readable label.
+- `timecodes` (List of String) — List of timecodes.
+- `linechart_values` (List of Number) — Values for line chart.
+- `treemap_values` (Number) — Value for treemap visualization.

--- a/docs/data-sources/system_volume_configs.md
+++ b/docs/data-sources/system_volume_configs.md
@@ -1,0 +1,80 @@
+---
+page_title: "emma_system_volume_configs Data Source - emma"
+subcategory: ""
+description: |-
+  Returns available configurations for system volumes, with optional filtering by attachment target, minimum size, and volume type.
+---
+
+# emma_system_volume_configs (Data Source)
+
+Returns a list of available system volume configurations in the Emma platform. Use this data source to discover valid sizes, types, and pricing for system volumes — for example, when planning a VM deployment or preparing to upsize an existing system disk.
+
+All filter attributes are optional — omit them to get all available configurations, or combine them to narrow results.
+
+Note: this data source does not support filtering by `provider_id`. Use the `provider_id` field in the returned configurations to filter results in your Terraform expressions.
+
+## Example Usage
+
+### List all system volume configurations
+
+```terraform
+data "emma_system_volume_configs" "all" {}
+
+output "config_count" {
+  value = length(data.emma_system_volume_configs.all.configurations)
+}
+```
+
+### Find SSD configurations of at least 100 GB
+
+```terraform
+data "emma_system_volume_configs" "large_ssd" {
+  volume_gb_min = 100
+  volume_type   = "ssd"
+}
+
+output "large_ssd_options" {
+  value = [for c in data.emma_system_volume_configs.large_ssd.configurations : {
+    data_center = c.data_center_id
+    size_gb     = c.volume_gb
+    price       = c.price_per_unit
+    currency    = c.price_currency
+  }]
+}
+```
+
+### Find valid upsizing options for an attached VM's system volume
+
+```terraform
+data "emma_system_volume_configs" "vm_options" {
+  attached_to_id = 4521
+  volume_gb_min  = 50
+}
+
+output "upsize_options" {
+  value = data.emma_system_volume_configs.vm_options.configurations
+}
+```
+
+## Schema
+
+### Optional
+
+- `attached_to_id` (Number) — ID of the compute instance the system volume is attached to. Use to scope results to valid configurations for a specific VM.
+- `volume_gb_min` (Number) — Minimum volume size in gigabytes to filter configurations.
+- `volume_type` (String) — Volume type to filter configurations (e.g. "ssd", "hdd").
+
+### Read-Only
+
+- `configurations` (List of Object) — List of matching system volume configurations. Each element has:
+  - `provider_id` (Number) — ID of the cloud provider
+  - `provider_name` (String) — Name of the cloud provider (e.g. "AWS", "Azure")
+  - `location_id` (Number) — Location ID
+  - `location_name` (String) — Location name (city or region)
+  - `data_center_id` (String) — ID of the data center (e.g. "aws-us-east-1")
+  - `data_center_name` (String) — Name of the data center
+  - `volume_gb` (Number) — Volume size in gigabytes
+  - `volume_type` (String) — Volume type (e.g. "ssd", "hdd")
+  - `price_per_unit` (Number) — Price per billing unit for this configuration
+  - `price_currency` (String) — Currency of the price (e.g. "EUR")
+  - `price_unit` (String) — Billing period (e.g. "MONTHS")

--- a/docs/data-sources/vm_configurations.md
+++ b/docs/data-sources/vm_configurations.md
@@ -1,0 +1,106 @@
+---
+page_title: "emma_vm_configurations Data Source - emma"
+subcategory: ""
+description: |-
+  Returns available virtual machine configurations filtered by GPU type, provider, data center, hardware specs, and price.
+---
+
+# emma_vm_configurations (Data Source)
+
+Returns a list of available virtual machine configurations. Use this data source to discover valid hardware configurations, pricing, and GPU availability before creating a virtual machine.
+
+All filter attributes are optional — omit them to get all configurations, or combine them to narrow results.
+
+## Example Usage
+
+### Find cheapest GPU VM configurations
+
+```terraform
+data "emma_accelerator_type" "t4" {
+  accelerator_type = "NVIDIA T4"
+}
+
+data "emma_vm_configurations" "gpu_t4" {
+  accelerator_type_id = data.emma_accelerator_type.t4.id
+  price_max           = 400
+}
+
+output "t4_configs" {
+  value = [for c in data.emma_vm_configurations.gpu_t4.configurations : {
+    provider    = c.provider_name
+    data_center = c.data_center_id
+    vcpu        = c.vcpu
+    ram_gb      = c.ram_gb
+    gpu         = c.accelerators
+    price       = c.price_per_unit
+  }]
+}
+```
+
+### Filter by provider and data center
+
+```terraform
+data "emma_vm_configurations" "azure_gpu" {
+  accelerator_type_id = "aaf51e31-b8d2-42dd-af72-cf3b6ec49370"
+  provider_id         = 256
+  ram_gb_min          = 14
+}
+
+output "azure_gpu_configs" {
+  value = data.emma_vm_configurations.azure_gpu.configurations
+}
+```
+
+### Find high-memory VMs
+
+```terraform
+data "emma_vm_configurations" "high_mem" {
+  ram_gb_min = 64
+  vcpu_min   = 8
+  vcpu_type  = "standard"
+}
+
+output "high_mem_configs_count" {
+  value = length(data.emma_vm_configurations.high_mem.configurations)
+}
+```
+
+## Schema
+
+### Optional
+
+- `accelerator_type_id` (String) Filter by GPU accelerator type ID. Use `emma_accelerator_types` or `emma_accelerator_type` data source to find the ID.
+- `data_center_id` (String) Filter by data center ID (e.g. "aws-us-east-2", "azure-westeurope")
+- `provider_id` (Number) Filter by cloud provider ID (e.g. 255 = AWS, 256 = Azure)
+- `vcpu_type` (String) Filter by vCPU type: "shared", "standard", or "hpc"
+- `vcpu_min` (Number) Minimum number of vCPUs
+- `vcpu_max` (Number) Maximum number of vCPUs
+- `ram_gb_min` (Number) Minimum RAM in gigabytes
+- `ram_gb_max` (Number) Maximum RAM in gigabytes
+- `volume_gb_min` (Number) Minimum volume size in gigabytes
+- `volume_gb_max` (Number) Maximum volume size in gigabytes
+- `price_min` (Number) Minimum price per unit
+- `price_max` (Number) Maximum price per unit
+
+### Read-Only
+
+- `configurations` (List of Object) List of matching VM configurations. Each element has:
+  - `provider_id` (Number) — Cloud provider ID
+  - `provider_name` (String) — Cloud provider name (e.g. "AWS", "Azure")
+  - `location_name` (String) — Location name
+  - `data_center_id` (String) — Data center ID
+  - `data_center_name` (String) — Data center name
+  - `os_id` (Number) — Operating system ID
+  - `os_type` (String) — Operating system type (e.g. "Ubuntu")
+  - `cloud_network_types` (List of String) — Available network types (e.g. ["default", "isolated", "multi-cloud"])
+  - `vcpu_type` (String) — vCPU type
+  - `vcpu` (Number) — Number of vCPUs
+  - `ram_gb` (Number) — RAM in gigabytes
+  - `volume_gb` (Number) — Volume size in gigabytes
+  - `volume_type` (String) — Volume type (e.g. "ssd", "ssd-plus")
+  - `accelerator_type_id` (String) — GPU accelerator type ID (empty if no GPU)
+  - `accelerator_type` (String) — GPU model name (empty if no GPU)
+  - `accelerators` (Number) — Number of GPU accelerators (0 if no GPU)
+  - `price_per_unit` (Number) — Price per unit period
+  - `price_currency` (String) — Currency (e.g. "EUR")
+  - `price_unit` (String) — Billing period (e.g. "MONTHS")

--- a/docs/data-sources/vm_resize_configs.md
+++ b/docs/data-sources/vm_resize_configs.md
@@ -1,0 +1,90 @@
+---
+page_title: "emma_vm_resize_configs Data Source - emma"
+subcategory: ""
+description: |-
+  Returns available hardware configurations for resizing an existing virtual machine, with optional filtering by VM ID and hardware constraints.
+---
+
+# emma_vm_resize_configs (Data Source)
+
+Returns a list of valid resize configurations for an existing virtual machine. Use this data source to discover which vCPU, RAM, and GPU combinations are available for a given VM before calling the VM edit endpoint.
+
+Unlike `emma_vm_configurations`, this data source does not return provider, location, or data center fields — results are scoped to configurations compatible with the VM's existing placement. The configurations include the provider-specific compute type identifier (`provider_compute_type`) needed for the resize API call.
+
+All filter attributes are optional.
+
+## Example Usage
+
+### List all resize configs for a specific VM
+
+```terraform
+data "emma_vm_resize_configs" "vm_4521" {
+  vm_id = 4521
+}
+
+output "resize_options" {
+  value = [for c in data.emma_vm_resize_configs.vm_4521.configurations : {
+    vcpu     = c.vcpu
+    ram_gb   = c.ram_gb
+    price    = c.price_per_unit
+    currency = c.price_currency
+  }]
+}
+```
+
+### Find resize configs with at least 16 vCPUs and 64 GB RAM under a price cap
+
+```terraform
+data "emma_vm_resize_configs" "upgrade" {
+  vm_id     = 4521
+  vcpu_min  = 16
+  ram_gb_min = 64
+  price_max = 500
+}
+
+output "upgrade_candidates" {
+  value = data.emma_vm_resize_configs.upgrade.configurations
+}
+```
+
+### Find GPU resize configs for a VM
+
+```terraform
+data "emma_vm_resize_configs" "gpu_upgrade" {
+  vm_id = 4521
+}
+
+output "gpu_resize_options" {
+  value = [
+    for c in data.emma_vm_resize_configs.gpu_upgrade.configurations : c
+    if c.accelerator_type != null && c.accelerator_type != ""
+  ]
+}
+```
+
+## Schema
+
+### Optional
+
+- `vm_id` (Number) — ID of the virtual machine to retrieve resize configurations for. When provided, results are scoped to configurations compatible with the VM's current placement.
+- `vcpu_type` (String) — Filter by vCPU type: "shared", "standard", or "hpc".
+- `vcpu_min` (Number) — Minimum number of vCPUs.
+- `vcpu_max` (Number) — Maximum number of vCPUs.
+- `ram_gb_min` (Number) — Minimum RAM in gigabytes.
+- `ram_gb_max` (Number) — Maximum RAM in gigabytes.
+- `price_min` (Number) — Minimum price per unit.
+- `price_max` (Number) — Maximum price per unit.
+
+### Read-Only
+
+- `configurations` (List of Object) — List of available VM resize configurations. Each element has:
+  - `vcpu_type` (String) — vCPU type: "shared", "standard", or "hpc"
+  - `vcpu` (Number) — Number of virtual CPUs
+  - `ram_gb` (Number) — RAM in gigabytes
+  - `provider_compute_type` (String) — Provider-specific compute type identifier (used in the resize API call)
+  - `accelerator_type_id` (String) — GPU accelerator type ID. Empty when no GPU is available.
+  - `accelerator_type` (String) — GPU accelerator type name (e.g. "NVIDIA T4"). Empty when no GPU is available.
+  - `accelerators` (Number) — Quantity of GPU accelerators. 0 when no GPU is available.
+  - `price_per_unit` (Number) — Price per billing unit for this configuration
+  - `price_currency` (String) — Currency of the price (e.g. "EUR")
+  - `price_unit` (String) — Billing period (e.g. "MONTHS")

--- a/docs/data-sources/vms.md
+++ b/docs/data-sources/vms.md
@@ -1,0 +1,73 @@
+---
+page_title: "emma_vms Data Source - emma"
+subcategory: ""
+description: |-
+  Returns a list of virtual machines in the project, with optional filtering by project ID.
+---
+
+# emma_vms (Data Source)
+
+Returns a list of virtual machines running in the Emma platform. Use this data source to enumerate existing VMs, inspect their status and placement, or reference VM IDs in other resources.
+
+All filter attributes are optional — omit `project_id` to return VMs across all projects your credentials can access.
+
+## Example Usage
+
+### List all VMs in the default project
+
+```terraform
+data "emma_vms" "all" {}
+
+output "vm_names" {
+  value = [for v in data.emma_vms.all.vms : v.name]
+}
+```
+
+### List VMs in a specific project
+
+```terraform
+data "emma_vms" "project" {
+  project_id = 1297
+}
+
+output "running_vms" {
+  value = [for v in data.emma_vms.project.vms : v if v.status == "active"]
+}
+```
+
+### Find VMs running in a specific data center
+
+```terraform
+data "emma_vms" "all" {}
+
+output "aws_east_vms" {
+  value = [for v in data.emma_vms.all.vms : v if v.data_center_id == "aws-us-east-1"]
+}
+```
+
+## Schema
+
+### Optional
+
+- `project_id` (Number) — Filter virtual machines by project ID. Omit to return VMs across all accessible projects.
+
+### Read-Only
+
+- `vms` (List of Object) — List of matching virtual machines. Each element has:
+  - `id` (Number) — ID of the virtual machine
+  - `name` (String) — Name of the virtual machine
+  - `status` (String) — Current status of the virtual machine (e.g. "active", "poweredOff")
+  - `project_id` (Number) — Project ID the virtual machine belongs to
+  - `provider_id` (Number) — ID of the cloud provider
+  - `provider_name` (String) — Name of the cloud provider (e.g. "AWS", "Azure")
+  - `location_id` (Number) — ID of the geographic location
+  - `location_name` (String) — Name of the geographic location
+  - `data_center_id` (String) — ID of the data center (e.g. "aws-us-east-1")
+  - `data_center_name` (String) — Name of the data center
+  - `os_id` (Number) — ID of the operating system
+  - `os_type` (String) — Type of the operating system (e.g. "Ubuntu")
+  - `vcpu` (Number) — Number of virtual CPUs
+  - `vcpu_type` (String) — vCPU type: "shared", "standard", or "hpc"
+  - `ram_gb` (Number) — RAM in gigabytes
+  - `cloud_network_type` (String) — Cloud network type of the virtual machine (e.g. "default", "isolated", "multi-cloud")
+  - `created_at` (String) — Date and time when the virtual machine was created (ISO 8601)

--- a/docs/data-sources/volumes.md
+++ b/docs/data-sources/volumes.md
@@ -1,0 +1,71 @@
+---
+page_title: "emma_volumes Data Source - emma"
+subcategory: ""
+description: |-
+  Returns a list of all storage volumes in the project.
+---
+
+# emma_volumes (Data Source)
+
+Returns a list of all storage volumes in the Emma platform. Use this data source to enumerate both system and data volumes, inspect their attachment status, or find volume IDs to reference in other resources.
+
+This data source returns all volumes accessible to your credentials and does not accept filter arguments — use Terraform's `for` expressions to filter the result list in your configuration.
+
+## Example Usage
+
+### List all volumes
+
+```terraform
+data "emma_volumes" "all" {}
+
+output "volume_names" {
+  value = [for v in data.emma_volumes.all.volumes : v.name]
+}
+```
+
+### Find all unattached data volumes
+
+```terraform
+data "emma_volumes" "all" {}
+
+output "free_volumes" {
+  value = [
+    for v in data.emma_volumes.all.volumes : v
+    if !v.is_system && v.attached_to_id == null
+  ]
+}
+```
+
+### Inspect volumes in a specific data center
+
+```terraform
+data "emma_volumes" "all" {}
+
+output "eu_west_volumes" {
+  value = [
+    for v in data.emma_volumes.all.volumes : v
+    if v.data_center_id == "aws-eu-west-1"
+  ]
+}
+```
+
+## Schema
+
+### Read-Only
+
+- `volumes` (List of Object) — List of all accessible storage volumes. Each element has:
+  - `id` (String) — Volume ID
+  - `name` (String) — Volume name
+  - `size_gb` (Number) — Volume size in gigabytes
+  - `volume_type` (String) — Volume type (e.g. "ssd", "hdd")
+  - `is_system` (Boolean) — Whether the volume contains the operating system
+  - `status` (String) — Current status of the volume (e.g. "active", "available")
+  - `attached_to_id` (Number) — ID of the compute instance the volume is attached to. Null when the volume is unattached.
+  - `project_id` (Number) — Project ID that owns the volume
+  - `data_center_id` (String) — Data center ID where the volume is located
+  - `created_at` (String) — Creation timestamp (ISO 8601)
+  - `created_by_name` (String) — Name of the user who created the volume
+  - `created_by_id` (Number) — ID of the user who created the volume
+  - `modified_at` (String) — Date and time when the volume was last modified (ISO 8601)
+  - `modified_by_name` (String) — Name of the user who last modified the volume
+  - `modified_by_id` (Number) — ID of the user who last modified the volume

--- a/docs/data-sources/workflow_templates.md
+++ b/docs/data-sources/workflow_templates.md
@@ -1,0 +1,69 @@
+---
+page_title: "emma_workflow_templates Data Source - emma"
+subcategory: ""
+description: |-
+  Returns a list of workflow templates in the Emma platform, with optional filtering by name or status.
+---
+
+# emma_workflow_templates (Data Source)
+
+Returns a list of workflow templates in the Emma platform. Use this data source to enumerate existing templates, look up IDs, or reference templates in other resources without importing them into Terraform state.
+
+All filter attributes are optional — omit them to return all accessible templates.
+
+To create and manage workflow templates as Terraform-owned infrastructure, use the [`emma_workflow_template` resource](../resources/workflow_template.md).
+
+## Example Usage
+
+### List all published templates
+
+```terraform
+data "emma_workflow_templates" "published" {
+  status = "PUBLISHED"
+}
+
+output "template_names" {
+  value = [for t in data.emma_workflow_templates.published.workflow_templates : t.name]
+}
+```
+
+### Find templates by name
+
+```terraform
+data "emma_workflow_templates" "backup" {
+  name_like = "backup"
+}
+
+output "backup_template_ids" {
+  value = [for t in data.emma_workflow_templates.backup.workflow_templates : {
+    id   = t.id
+    name = t.name
+  }]
+}
+```
+
+## Schema
+
+### Optional
+
+- `name_like` (String) — Filter workflow templates by name using partial match.
+- `status` (String) — Filter workflow templates by status: `PUBLISHED` or `UNPUBLISHED`.
+
+### Read-Only
+
+- `workflow_templates` (List of Object) — List of matching workflow templates. Each element has:
+  - `id` (String) — ID of the workflow template.
+  - `name` (String) — Name of the workflow template.
+  - `description` (String) — Description of the workflow template.
+  - `content_type` (String) — Format of the content field.
+  - `content` (String) — Content of the workflow template.
+  - `status` (String) — Status of the workflow template (`PUBLISHED` or `UNPUBLISHED`).
+  - `resource_type` (String) — Type of the resource.
+  - `created_at` (String) — Date and time when the workflow template was created (ISO 8601).
+  - `created_by_name` (String) — Name of the user who created the workflow template.
+  - `created_by_id` (String) — ID of the user who created the workflow template.
+  - `modified_at` (String) — Date and time when the workflow template was last modified (ISO 8601).
+  - `modified_by_name` (String) — Name of the user who last modified the workflow template.
+  - `modified_by_id` (String) — ID of the user who last modified the workflow template.
+  - `is_deleted` (Boolean) — Indicates whether the workflow template is deleted.
+  - `is_content_valid` (Boolean) — Indicates whether the content of the workflow template is valid.

--- a/docs/resources/spot_instance.md
+++ b/docs/resources/spot_instance.md
@@ -77,6 +77,7 @@ resource "emma_spot_instance" "gpu_spot" {
   ram_gb              = 16
   volume_type         = "ssd"
   volume_gb           = 50
+  security_group_id   = emma_security_group.security_group.id
   ssh_key_id          = emma_ssh_key.ssh_key.id
   price               = 0.15
   accelerator_type_id = data.emma_accelerator_type.nvidia_t4.id

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -67,6 +67,7 @@ resource "emma_vm" "gpu_vm" {
   ram_gb              = 32
   volume_type         = "ssd"
   volume_gb           = 100
+  security_group_id   = emma_security_group.security_group.id
   ssh_key_id          = emma_ssh_key.ssh_key.id
   accelerator_type_id = data.emma_accelerator_type.nvidia_a100.id
   accelerators        = 1

--- a/docs/resources/workflow_template.md
+++ b/docs/resources/workflow_template.md
@@ -1,0 +1,140 @@
+---
+page_title: "emma_workflow_template Resource - emma"
+subcategory: ""
+description: |-
+  Manages a workflow template. A workflow template is a predefined blueprint for a workflow that includes shell commands and parameters. It serves as a starting point for creating workflows, allowing users to quickly set up and execute common processes.
+---
+
+# emma_workflow_template (Resource)
+
+Manages a workflow template in Emma. A workflow template is a predefined blueprint for a workflow that includes shell commands and parameters. It serves as a starting point for creating workflows, allowing users to quickly set up and execute common processes.
+
+To list existing templates without managing them, use the [`emma_workflow_templates` data source](../data-sources/workflow_templates.md).
+
+## Example Usage
+
+### Minimal template
+
+```terraform
+resource "emma_workflow_template" "backup" {
+  name          = "daily-backup"
+  content_type  = "Shell"
+  status        = "PUBLISHED"
+  resource_type = "COMPUTE"
+
+  content = <<-EOT
+    #!/bin/bash
+    set -e
+    echo "Starting backup at $(date)"
+    tar czf /tmp/backup.tar.gz /var/data
+    echo "Backup complete"
+  EOT
+}
+```
+
+### Template with resource constraints, content parameters, and tags
+
+```terraform
+resource "emma_workflow_template" "deploy" {
+  name          = "app-deploy"
+  description   = "Deploys the application to a target VM"
+  content_type  = "Shell"
+  status        = "PUBLISHED"
+  resource_type = "COMPUTE"
+
+  content = <<-EOT
+    #!/bin/bash
+    set -e
+    APP_VERSION="${APP_VERSION}"
+    TARGET_ENV="${TARGET_ENV}"
+    echo "Deploying $APP_VERSION to $TARGET_ENV"
+    # deployment steps here
+  EOT
+
+  resource_params = [
+    {
+      name  = "minCpuCores"
+      value = "4"
+    },
+    {
+      name  = "minRamSizeGb"
+      value = "8"
+    },
+  ]
+
+  content_params = [
+    {
+      name          = "APP_VERSION"
+      default_value = "latest"
+      mandatory     = true
+    },
+    {
+      name          = "TARGET_ENV"
+      default_value = "production"
+      mandatory     = false
+    },
+  ]
+
+  tags = [
+    {
+      tag_id = null
+      key    = "team"
+      value  = "platform"
+    },
+    {
+      tag_id = null
+      key    = "environment"
+      value  = "production"
+    },
+  ]
+}
+
+output "template_id" {
+  value = emma_workflow_template.deploy.id
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (String) — Name of the workflow template.
+- `content_type` (String) — Format of the content field. Only `Shell` is supported.
+- `content` (String) — Content of the workflow template. For `Shell` content type, contains the shell commands to execute.
+- `status` (String) — Status of the workflow template. Valid values: `PUBLISHED`, `UNPUBLISHED`.
+- `resource_type` (String) — Type of the resource. Use `COMPUTE`.
+
+### Optional
+
+- `description` (String) — Description of the workflow template.
+- `resource_params` (List of Object) — Parameters that constrain the resources a workflow may run on (e.g. minimum CPU, RAM). Each object has:
+  - `name` (String) — Parameter name (e.g. `minCpuCores`, `minRamSizeGb`, `minVolumeSizeGb`).
+  - `value` (String) — Parameter value.
+- `content_params` (List of Object) — Template placeholder parameters. These fill in variables in `content` when a workflow is created from this template. Each object has:
+  - `name` (String) — Name of the content parameter.
+  - `default_value` (String) — Default value of the parameter.
+  - `mandatory` (Boolean) — Whether the parameter must be supplied when creating a workflow.
+- `tags` (List of Object) — Tags assigned to the workflow template. Each object has:
+  - `tag_id` (String) — ID of an existing tag (may be `null` when creating new tags).
+  - `key` (String) — Tag key (e.g. `environment`, `team`).
+  - `value` (String) — Tag value.
+
+### Read-Only
+
+- `id` (String) — ID of the workflow template.
+- `created_at` (String) — Date and time when the workflow template was created (ISO 8601).
+- `created_by_name` (String) — Name of the user who created the workflow template.
+- `created_by_id` (String) — ID of the user who created the workflow template.
+- `modified_at` (String) — Date and time when the workflow template was last modified (ISO 8601).
+- `modified_by_name` (String) — Name of the user who last modified the workflow template.
+- `modified_by_id` (String) — ID of the user who last modified the workflow template.
+- `is_deleted` (Boolean) — Indicates whether the workflow template is deleted.
+- `is_content_valid` (Boolean) — Indicates whether the content of the workflow template is valid.
+
+## Import
+
+Workflow templates can be imported using their ID:
+
+```shell
+terraform import emma_workflow_template.foo <id>
+```

--- a/internal/emma/accelerator_types_data_source.go
+++ b/internal/emma/accelerator_types_data_source.go
@@ -1,0 +1,145 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &acceleratorTypesDataSource{}
+
+func NewAcceleratorTypesDataSource() datasource.DataSource {
+	return &acceleratorTypesDataSource{}
+}
+
+// acceleratorTypesDataSource defines the data source implementation.
+type acceleratorTypesDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// acceleratorTypesDataSourceModel describes the data source data model.
+type acceleratorTypesDataSourceModel struct {
+	AcceleratorTypes types.List `tfsdk:"accelerator_types"`
+}
+
+// acceleratorTypeItemModel describes individual accelerator type items in the list.
+type acceleratorTypeItemModel struct {
+	Id              types.String `tfsdk:"id"`
+	AcceleratorType types.String `tfsdk:"accelerator_type"`
+}
+
+func (d *acceleratorTypesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_accelerator_types"
+}
+
+func (d *acceleratorTypesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a list of all available GPU accelerator types that can be used with compute instances.",
+		Attributes: map[string]schema.Attribute{
+			"accelerator_types": schema.ListNestedAttribute{
+				Description: "List of available accelerator types",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "ID of the accelerator type",
+							Computed:    true,
+						},
+						"accelerator_type": schema.StringAttribute{
+							Description: "Name of the accelerator type (e.g. NVIDIA A100, NVIDIA T4)",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *acceleratorTypesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *acceleratorTypesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data acceleratorTypesDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	acceleratorTypes, response, err := d.apiClient.AcceleratorTypesAPI.GetAcceleratorTypes(auth).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read accelerator types, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	typeList, diags := convertAcceleratorTypesToList(ctx, acceleratorTypes)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.AcceleratorTypes = typeList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Helper function to get attribute types for accelerator type nested object
+func (o acceleratorTypeItemModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":               types.StringType,
+		"accelerator_type": types.StringType,
+	}
+}
+
+// convertAcceleratorTypesToList converts Emma API accelerator types response to Terraform list
+func convertAcceleratorTypesToList(ctx context.Context, acceleratorTypes []emmaSdk.AcceleratorType) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var itemModels []acceleratorTypeItemModel
+
+	for _, at := range acceleratorTypes {
+		item := acceleratorTypeItemModel{}
+
+		if at.Id != nil {
+			item.Id = types.StringValue(*at.Id)
+		} else {
+			item.Id = types.StringNull()
+		}
+
+		if at.AcceleratorType != nil {
+			item.AcceleratorType = types.StringValue(*at.AcceleratorType)
+		} else {
+			item.AcceleratorType = types.StringNull()
+		}
+
+		itemModels = append(itemModels, item)
+	}
+
+	typeList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: acceleratorTypeItemModel{}.attrTypes()}, itemModels)
+	diags.Append(listDiags...)
+
+	return typeList, diags
+}

--- a/internal/emma/kuber_nodes_configs_data_source.go
+++ b/internal/emma/kuber_nodes_configs_data_source.go
@@ -1,0 +1,532 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &kuberNodesConfigsDataSource{}
+
+func NewKuberNodesConfigsDataSource() datasource.DataSource {
+	return &kuberNodesConfigsDataSource{}
+}
+
+type kuberNodesConfigsDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+type kuberNodesConfigsDataSourceModel struct {
+	K8sConnectionType types.String  `tfsdk:"k8s_connection_type"`
+	ProviderId        types.Int64   `tfsdk:"provider_id"`
+	LocationId        types.Int64   `tfsdk:"location_id"`
+	AcceleratorTypeId types.String  `tfsdk:"accelerator_type_id"`
+	AcceleratorsMin   types.Float64 `tfsdk:"accelerators_min"`
+	AcceleratorsMax   types.Float64 `tfsdk:"accelerators_max"`
+	DataCenterId      types.String  `tfsdk:"data_center_id"`
+	VCpuType          types.String  `tfsdk:"vcpu_type"`
+	VCpuMin           types.Int64   `tfsdk:"vcpu_min"`
+	VCpuMax           types.Int64   `tfsdk:"vcpu_max"`
+	RamGbMin          types.Int64   `tfsdk:"ram_gb_min"`
+	RamGbMax          types.Int64   `tfsdk:"ram_gb_max"`
+	VolumeGbMin       types.Int64   `tfsdk:"volume_gb_min"`
+	VolumeGbMax       types.Int64   `tfsdk:"volume_gb_max"`
+	VolumeType        types.String  `tfsdk:"volume_type"`
+	PriceMin          types.Float64 `tfsdk:"price_min"`
+	PriceMax          types.Float64 `tfsdk:"price_max"`
+	Configurations    types.List    `tfsdk:"configurations"`
+}
+
+type kuberNodeConfigurationModel struct {
+	Id                types.String  `tfsdk:"id"`
+	ProviderId        types.Int64   `tfsdk:"provider_id"`
+	ProviderName      types.String  `tfsdk:"provider_name"`
+	LocationId        types.Int64   `tfsdk:"location_id"`
+	LocationName      types.String  `tfsdk:"location_name"`
+	DataCenterId      types.String  `tfsdk:"data_center_id"`
+	DataCenterName    types.String  `tfsdk:"data_center_name"`
+	OsId              types.Int64   `tfsdk:"os_id"`
+	OsType            types.String  `tfsdk:"os_type"`
+	OsVersion         types.String  `tfsdk:"os_version"`
+	CloudNetworkTypes types.List    `tfsdk:"cloud_network_types"`
+	VCpuType          types.String  `tfsdk:"vcpu_type"`
+	VCpu              types.Int64   `tfsdk:"vcpu"`
+	RamGb             types.Int64   `tfsdk:"ram_gb"`
+	VolumeGb          types.Int64   `tfsdk:"volume_gb"`
+	VolumeType        types.String  `tfsdk:"volume_type"`
+	AcceleratorTypeId types.String  `tfsdk:"accelerator_type_id"`
+	AcceleratorType   types.String  `tfsdk:"accelerator_type"`
+	Accelerators      types.Float64 `tfsdk:"accelerators"`
+	PricePerUnit      types.Float64 `tfsdk:"price_per_unit"`
+	PriceCurrency     types.String  `tfsdk:"price_currency"`
+	PriceUnit         types.String  `tfsdk:"price_unit"`
+}
+
+func (d *kuberNodesConfigsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_kuber_nodes_configs"
+}
+
+func (d *kuberNodesConfigsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source retrieves available hardware configurations for Kubernetes cluster worker nodes in the Emma platform.\n\n" +
+			"Use this data source to discover valid node types, CPU/RAM/storage options, and GPU configurations when planning Kubernetes cluster deployments.",
+		Attributes: map[string]schema.Attribute{
+			"k8s_connection_type": schema.StringAttribute{
+				Description: "Type of Kubernetes cluster network connectivity (e.g., public, private)",
+				Required:    true,
+			},
+			"provider_id": schema.Int64Attribute{
+				Description: "ID of the cloud provider to filter configurations",
+				Optional:    true,
+			},
+			"location_id": schema.Int64Attribute{
+				Description: "ID of the geographic location to filter configurations",
+				Optional:    true,
+			},
+			"accelerator_type_id": schema.StringAttribute{
+				Description: "GPU accelerator type ID to filter configurations",
+				Optional:    true,
+			},
+			"accelerators_min": schema.Float64Attribute{
+				Description: "Minimum quantity of GPU accelerators to filter configurations",
+				Optional:    true,
+			},
+			"accelerators_max": schema.Float64Attribute{
+				Description: "Maximum quantity of GPU accelerators to filter configurations",
+				Optional:    true,
+			},
+			"data_center_id": schema.StringAttribute{
+				Description: "ID of the data center to filter configurations",
+				Optional:    true,
+			},
+			"vcpu_type": schema.StringAttribute{
+				Description: "vCPU type to filter configurations (shared, standard, hpc)",
+				Optional:    true,
+			},
+			"vcpu_min": schema.Int64Attribute{
+				Description: "Minimum number of vCPUs to filter configurations",
+				Optional:    true,
+			},
+			"vcpu_max": schema.Int64Attribute{
+				Description: "Maximum number of vCPUs to filter configurations",
+				Optional:    true,
+			},
+			"ram_gb_min": schema.Int64Attribute{
+				Description: "Minimum RAM in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"ram_gb_max": schema.Int64Attribute{
+				Description: "Maximum RAM in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"volume_gb_min": schema.Int64Attribute{
+				Description: "Minimum volume size in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"volume_gb_max": schema.Int64Attribute{
+				Description: "Maximum volume size in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"volume_type": schema.StringAttribute{
+				Description: "Volume type to filter configurations",
+				Optional:    true,
+			},
+			"price_min": schema.Float64Attribute{
+				Description: "Minimum price to filter configurations",
+				Optional:    true,
+			},
+			"price_max": schema.Float64Attribute{
+				Description: "Maximum price to filter configurations",
+				Optional:    true,
+			},
+			"configurations": schema.ListNestedAttribute{
+				Description: "List of available Kubernetes node configurations",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "Configuration ID",
+							Computed:    true,
+						},
+						"provider_id": schema.Int64Attribute{
+							Description: "ID of the cloud provider",
+							Computed:    true,
+						},
+						"provider_name": schema.StringAttribute{
+							Description: "Name of the cloud provider",
+							Computed:    true,
+						},
+						"location_id": schema.Int64Attribute{
+							Description: "Location ID",
+							Computed:    true,
+						},
+						"location_name": schema.StringAttribute{
+							Description: "Location name (city or state)",
+							Computed:    true,
+						},
+						"data_center_id": schema.StringAttribute{
+							Description: "ID of the data center",
+							Computed:    true,
+						},
+						"data_center_name": schema.StringAttribute{
+							Description: "Name of the data center",
+							Computed:    true,
+						},
+						"os_id": schema.Int64Attribute{
+							Description: "ID of the operating system",
+							Computed:    true,
+						},
+						"os_type": schema.StringAttribute{
+							Description: "Type of the operating system",
+							Computed:    true,
+						},
+						"os_version": schema.StringAttribute{
+							Description: "Version of the operating system",
+							Computed:    true,
+						},
+						"cloud_network_types": schema.ListAttribute{
+							Description: "List of supported cloud network types",
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+						"vcpu_type": schema.StringAttribute{
+							Description: "vCPU type (shared, standard, hpc)",
+							Computed:    true,
+						},
+						"vcpu": schema.Int64Attribute{
+							Description: "Number of virtual CPUs",
+							Computed:    true,
+						},
+						"ram_gb": schema.Int64Attribute{
+							Description: "RAM in gigabytes",
+							Computed:    true,
+						},
+						"volume_gb": schema.Int64Attribute{
+							Description: "Volume size in gigabytes",
+							Computed:    true,
+						},
+						"volume_type": schema.StringAttribute{
+							Description: "Volume type (e.g., ssd, hdd)",
+							Computed:    true,
+						},
+						"accelerator_type_id": schema.StringAttribute{
+							Description: "GPU accelerator type ID",
+							Computed:    true,
+						},
+						"accelerator_type": schema.StringAttribute{
+							Description: "GPU accelerator type name",
+							Computed:    true,
+						},
+						"accelerators": schema.Float64Attribute{
+							Description: "Number of GPU accelerators",
+							Computed:    true,
+						},
+						"price_per_unit": schema.Float64Attribute{
+							Description: "Price per unit for this configuration",
+							Computed:    true,
+						},
+						"price_currency": schema.StringAttribute{
+							Description: "Currency of the price",
+							Computed:    true,
+						},
+						"price_unit": schema.StringAttribute{
+							Description: "Billing unit for the price",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *kuberNodesConfigsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *kuberNodesConfigsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data kuberNodesConfigsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	apiReq := d.apiClient.ComputeInstancesConfigurationsAPI.GetKuberNodesConfigs(auth)
+	apiReq = apiReq.K8sConnectionType(data.K8sConnectionType.ValueString())
+
+	if !data.ProviderId.IsNull() && !data.ProviderId.IsUnknown() {
+		apiReq = apiReq.ProviderId(int32(data.ProviderId.ValueInt64()))
+	}
+	if !data.LocationId.IsNull() && !data.LocationId.IsUnknown() {
+		apiReq = apiReq.LocationId(int32(data.LocationId.ValueInt64()))
+	}
+	if !data.AcceleratorTypeId.IsNull() && !data.AcceleratorTypeId.IsUnknown() {
+		apiReq = apiReq.AcceleratorTypeId(data.AcceleratorTypeId.ValueString())
+	}
+	if !data.AcceleratorsMin.IsNull() && !data.AcceleratorsMin.IsUnknown() {
+		apiReq = apiReq.AcceleratorsMin(float32(data.AcceleratorsMin.ValueFloat64()))
+	}
+	if !data.AcceleratorsMax.IsNull() && !data.AcceleratorsMax.IsUnknown() {
+		apiReq = apiReq.AcceleratorsMax(float32(data.AcceleratorsMax.ValueFloat64()))
+	}
+	if !data.DataCenterId.IsNull() && !data.DataCenterId.IsUnknown() {
+		apiReq = apiReq.DataCenterId(data.DataCenterId.ValueString())
+	}
+	if !data.VCpuType.IsNull() && !data.VCpuType.IsUnknown() {
+		apiReq = apiReq.VCpuType(data.VCpuType.ValueString())
+	}
+	if !data.VCpuMin.IsNull() && !data.VCpuMin.IsUnknown() {
+		apiReq = apiReq.VCpuMin(int32(data.VCpuMin.ValueInt64()))
+	}
+	if !data.VCpuMax.IsNull() && !data.VCpuMax.IsUnknown() {
+		apiReq = apiReq.VCpuMax(int32(data.VCpuMax.ValueInt64()))
+	}
+	if !data.RamGbMin.IsNull() && !data.RamGbMin.IsUnknown() {
+		apiReq = apiReq.RamGbMin(int32(data.RamGbMin.ValueInt64()))
+	}
+	if !data.RamGbMax.IsNull() && !data.RamGbMax.IsUnknown() {
+		apiReq = apiReq.RamGbMax(int32(data.RamGbMax.ValueInt64()))
+	}
+	if !data.VolumeGbMin.IsNull() && !data.VolumeGbMin.IsUnknown() {
+		apiReq = apiReq.VolumeGbMin(int32(data.VolumeGbMin.ValueInt64()))
+	}
+	if !data.VolumeGbMax.IsNull() && !data.VolumeGbMax.IsUnknown() {
+		apiReq = apiReq.VolumeGbMax(int32(data.VolumeGbMax.ValueInt64()))
+	}
+	if !data.VolumeType.IsNull() && !data.VolumeType.IsUnknown() {
+		apiReq = apiReq.VolumeType(data.VolumeType.ValueString())
+	}
+	if !data.PriceMin.IsNull() && !data.PriceMin.IsUnknown() {
+		apiReq = apiReq.PriceMin(float32(data.PriceMin.ValueFloat64()))
+	}
+	if !data.PriceMax.IsNull() && !data.PriceMax.IsUnknown() {
+		apiReq = apiReq.PriceMax(float32(data.PriceMax.ValueFloat64()))
+	}
+	apiReq = apiReq.Size(100)
+	configs, response, err := apiReq.Execute()
+
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read Kubernetes node configurations, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	configList, diags := convertKuberNodesConfigsToList(ctx, configs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Configurations = configList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (o kuberNodeConfigurationModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":                  types.StringType,
+		"provider_id":         types.Int64Type,
+		"provider_name":       types.StringType,
+		"location_id":         types.Int64Type,
+		"location_name":       types.StringType,
+		"data_center_id":      types.StringType,
+		"data_center_name":    types.StringType,
+		"os_id":               types.Int64Type,
+		"os_type":             types.StringType,
+		"os_version":          types.StringType,
+		"cloud_network_types": types.ListType{ElemType: types.StringType},
+		"vcpu_type":           types.StringType,
+		"vcpu":                types.Int64Type,
+		"ram_gb":              types.Int64Type,
+		"volume_gb":           types.Int64Type,
+		"volume_type":         types.StringType,
+		"accelerator_type_id": types.StringType,
+		"accelerator_type":    types.StringType,
+		"accelerators":        types.Float64Type,
+		"price_per_unit":      types.Float64Type,
+		"price_currency":      types.StringType,
+		"price_unit":          types.StringType,
+	}
+}
+
+func convertKuberNodesConfigsToList(ctx context.Context, configs *emmaSdk.GetKuberNodesConfigs200Response) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var configModels []kuberNodeConfigurationModel
+
+	if configs == nil || configs.Content == nil {
+		emptyList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: kuberNodeConfigurationModel{}.attrTypes()}, []kuberNodeConfigurationModel{})
+		diags.Append(listDiags...)
+		return emptyList, diags
+	}
+
+	for _, config := range configs.Content {
+		configModel := kuberNodeConfigurationModel{}
+
+		if config.Id != nil {
+			configModel.Id = types.StringValue(*config.Id)
+		} else {
+			configModel.Id = types.StringNull()
+		}
+
+		if config.ProviderId != nil {
+			configModel.ProviderId = types.Int64Value(int64(*config.ProviderId))
+		} else {
+			configModel.ProviderId = types.Int64Null()
+		}
+
+		if config.ProviderName != nil {
+			configModel.ProviderName = types.StringValue(*config.ProviderName)
+		} else {
+			configModel.ProviderName = types.StringNull()
+		}
+
+		if config.LocationId != nil {
+			configModel.LocationId = types.Int64Value(int64(*config.LocationId))
+		} else {
+			configModel.LocationId = types.Int64Null()
+		}
+
+		if config.LocationName != nil {
+			configModel.LocationName = types.StringValue(*config.LocationName)
+		} else {
+			configModel.LocationName = types.StringNull()
+		}
+
+		if config.DataCenterId != nil {
+			configModel.DataCenterId = types.StringValue(*config.DataCenterId)
+		} else {
+			configModel.DataCenterId = types.StringNull()
+		}
+
+		if config.DataCenterName != nil {
+			configModel.DataCenterName = types.StringValue(*config.DataCenterName)
+		} else {
+			configModel.DataCenterName = types.StringNull()
+		}
+
+		if config.OsId != nil {
+			configModel.OsId = types.Int64Value(int64(*config.OsId))
+		} else {
+			configModel.OsId = types.Int64Null()
+		}
+
+		if config.OsType != nil {
+			configModel.OsType = types.StringValue(*config.OsType)
+		} else {
+			configModel.OsType = types.StringNull()
+		}
+
+		if config.OsVersion != nil {
+			configModel.OsVersion = types.StringValue(*config.OsVersion)
+		} else {
+			configModel.OsVersion = types.StringNull()
+		}
+
+		cloudNetworkTypesList, listDiags := types.ListValueFrom(ctx, types.StringType, config.CloudNetworkTypes)
+		diags.Append(listDiags...)
+		configModel.CloudNetworkTypes = cloudNetworkTypesList
+
+		if config.VCpuType != nil {
+			configModel.VCpuType = types.StringValue(*config.VCpuType)
+		} else {
+			configModel.VCpuType = types.StringNull()
+		}
+
+		if config.VCpu != nil {
+			configModel.VCpu = types.Int64Value(int64(*config.VCpu))
+		} else {
+			configModel.VCpu = types.Int64Null()
+		}
+
+		if config.RamGb != nil {
+			configModel.RamGb = types.Int64Value(int64(*config.RamGb))
+		} else {
+			configModel.RamGb = types.Int64Null()
+		}
+
+		if config.VolumeGb != nil {
+			configModel.VolumeGb = types.Int64Value(int64(*config.VolumeGb))
+		} else {
+			configModel.VolumeGb = types.Int64Null()
+		}
+
+		if config.VolumeType != nil {
+			configModel.VolumeType = types.StringValue(*config.VolumeType)
+		} else {
+			configModel.VolumeType = types.StringNull()
+		}
+
+		if config.Accelerator != nil {
+			if config.Accelerator.AcceleratorTypeId != nil {
+				configModel.AcceleratorTypeId = types.StringValue(*config.Accelerator.AcceleratorTypeId)
+			} else {
+				configModel.AcceleratorTypeId = types.StringNull()
+			}
+			if config.Accelerator.AcceleratorType != nil {
+				configModel.AcceleratorType = types.StringValue(*config.Accelerator.AcceleratorType)
+			} else {
+				configModel.AcceleratorType = types.StringNull()
+			}
+			if config.Accelerator.Accelerators != nil {
+				configModel.Accelerators = types.Float64Value(float64(*config.Accelerator.Accelerators))
+			} else {
+				configModel.Accelerators = types.Float64Null()
+			}
+		} else {
+			configModel.AcceleratorTypeId = types.StringNull()
+			configModel.AcceleratorType = types.StringNull()
+			configModel.Accelerators = types.Float64Null()
+		}
+
+		if config.Cost != nil {
+			if config.Cost.PricePerUnit != nil {
+				configModel.PricePerUnit = types.Float64Value(float64(*config.Cost.PricePerUnit))
+			} else {
+				configModel.PricePerUnit = types.Float64Null()
+			}
+			if config.Cost.Currency != nil {
+				configModel.PriceCurrency = types.StringValue(*config.Cost.Currency)
+			} else {
+				configModel.PriceCurrency = types.StringNull()
+			}
+			if config.Cost.Unit != nil {
+				configModel.PriceUnit = types.StringValue(*config.Cost.Unit)
+			} else {
+				configModel.PriceUnit = types.StringNull()
+			}
+		} else {
+			configModel.PricePerUnit = types.Float64Null()
+			configModel.PriceCurrency = types.StringNull()
+			configModel.PriceUnit = types.StringNull()
+		}
+
+		configModels = append(configModels, configModel)
+	}
+
+	configList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: kuberNodeConfigurationModel{}.attrTypes()}, configModels)
+	diags.Append(listDiags...)
+
+	return configList, diags
+}

--- a/internal/emma/kubernetes_clusters_data_source.go
+++ b/internal/emma/kubernetes_clusters_data_source.go
@@ -199,7 +199,7 @@ func (o kubernetesClusterItemModel) attrTypes() map[string]attr.Type {
 // convertKubernetesClustersToList converts Emma API Kubernetes clusters response to Terraform list
 func convertKubernetesClustersToList(ctx context.Context, clusters []emmaSdk.KubernetesListResponseInner) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var itemModels []kubernetesClusterItemModel
+	itemModels := make([]kubernetesClusterItemModel, 0, len(clusters))
 
 	for _, c := range clusters {
 		item := kubernetesClusterItemModel{}

--- a/internal/emma/kubernetes_clusters_data_source.go
+++ b/internal/emma/kubernetes_clusters_data_source.go
@@ -1,0 +1,298 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &kubernetesClustersDataSource{}
+
+func NewKubernetesClustersDataSource() datasource.DataSource {
+	return &kubernetesClustersDataSource{}
+}
+
+// kubernetesClustersDataSource defines the data source implementation.
+type kubernetesClustersDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// kubernetesClustersDataSourceModel describes the data source data model.
+type kubernetesClustersDataSourceModel struct {
+	ProjectId           types.Int64 `tfsdk:"project_id"`
+	KubernetesClusters  types.List  `tfsdk:"kubernetes_clusters"`
+}
+
+// kubernetesClusterItemModel describes individual Kubernetes cluster items in the list.
+type kubernetesClusterItemModel struct {
+	Id                 types.Int64  `tfsdk:"id"`
+	Name               types.String `tfsdk:"name"`
+	Status             types.String `tfsdk:"status"`
+	ControlPlaneStatus types.String `tfsdk:"control_plane_status"`
+	Version            types.String `tfsdk:"version"`
+	DeploymentLocation types.String `tfsdk:"deployment_location"`
+	K8sConnectionType  types.String `tfsdk:"k8s_connection_type"`
+	DomainName         types.String `tfsdk:"domain_name"`
+	CreatedAt          types.String `tfsdk:"created_at"`
+	CreatedByName      types.String `tfsdk:"created_by_name"`
+	CreatedById        types.Int64  `tfsdk:"created_by_id"`
+	ModifiedAt         types.String `tfsdk:"modified_at"`
+	ModifiedByName     types.String `tfsdk:"modified_by_name"`
+	ModifiedById       types.Int64  `tfsdk:"modified_by_id"`
+}
+
+func (d *kubernetesClustersDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_kubernetes_clusters"
+}
+
+func (d *kubernetesClustersDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a list of Kubernetes clusters. Optionally filter by project ID.",
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.Int64Attribute{
+				Description: "Optional project ID to filter clusters",
+				Optional:    true,
+			},
+			"kubernetes_clusters": schema.ListNestedAttribute{
+				Description: "List of Kubernetes clusters",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.Int64Attribute{
+							Description: "Kubernetes cluster ID",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "Kubernetes cluster name",
+							Computed:    true,
+						},
+						"status": schema.StringAttribute{
+							Description: "Status of the Kubernetes cluster",
+							Computed:    true,
+						},
+						"control_plane_status": schema.StringAttribute{
+							Description: "Control plane status",
+							Computed:    true,
+						},
+						"version": schema.StringAttribute{
+							Description: "Kubernetes cluster version",
+							Computed:    true,
+						},
+						"deployment_location": schema.StringAttribute{
+							Description: "Deployment region of the Kubernetes cluster",
+							Computed:    true,
+						},
+						"k8s_connection_type": schema.StringAttribute{
+							Description: "Kubernetes connection type",
+							Computed:    true,
+						},
+						"domain_name": schema.StringAttribute{
+							Description: "Domain attached to the Kubernetes cluster",
+							Computed:    true,
+						},
+						"created_at": schema.StringAttribute{
+							Description: "Date and time of the Kubernetes cluster creation",
+							Computed:    true,
+						},
+						"created_by_name": schema.StringAttribute{
+							Description: "Name of the user who created the Kubernetes cluster",
+							Computed:    true,
+						},
+						"created_by_id": schema.Int64Attribute{
+							Description: "ID of the user who created the Kubernetes cluster",
+							Computed:    true,
+						},
+						"modified_at": schema.StringAttribute{
+							Description: "Date and time when the Kubernetes cluster was last modified",
+							Computed:    true,
+						},
+						"modified_by_name": schema.StringAttribute{
+							Description: "Name of the user who last modified the Kubernetes cluster",
+							Computed:    true,
+						},
+						"modified_by_id": schema.Int64Attribute{
+							Description: "ID of the user who last modified the Kubernetes cluster",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *kubernetesClustersDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *kubernetesClustersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data kubernetesClustersDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	apiReq := d.apiClient.KubernetesClustersAPI.GetKubernetesClusters(auth)
+	if !data.ProjectId.IsNull() && !data.ProjectId.IsUnknown() {
+		apiReq = apiReq.ProjectId(int32(data.ProjectId.ValueInt64()))
+	}
+
+	clusters, response, err := apiReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read Kubernetes clusters, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	clusterList, diags := convertKubernetesClustersToList(ctx, clusters)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.KubernetesClusters = clusterList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Helper function to get attribute types for Kubernetes cluster nested object
+func (o kubernetesClusterItemModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":                   types.Int64Type,
+		"name":                 types.StringType,
+		"status":               types.StringType,
+		"control_plane_status": types.StringType,
+		"version":              types.StringType,
+		"deployment_location":  types.StringType,
+		"k8s_connection_type":  types.StringType,
+		"domain_name":          types.StringType,
+		"created_at":           types.StringType,
+		"created_by_name":      types.StringType,
+		"created_by_id":        types.Int64Type,
+		"modified_at":          types.StringType,
+		"modified_by_name":     types.StringType,
+		"modified_by_id":       types.Int64Type,
+	}
+}
+
+// convertKubernetesClustersToList converts Emma API Kubernetes clusters response to Terraform list
+func convertKubernetesClustersToList(ctx context.Context, clusters []emmaSdk.KubernetesListResponseInner) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var itemModels []kubernetesClusterItemModel
+
+	for _, c := range clusters {
+		item := kubernetesClusterItemModel{}
+
+		if c.Id != nil {
+			item.Id = types.Int64Value(int64(*c.Id))
+		} else {
+			item.Id = types.Int64Null()
+		}
+
+		if c.Name != nil {
+			item.Name = types.StringValue(*c.Name)
+		} else {
+			item.Name = types.StringNull()
+		}
+
+		if c.Status != nil {
+			item.Status = types.StringValue(*c.Status)
+		} else {
+			item.Status = types.StringNull()
+		}
+
+		if c.ControlPlaneStatus != nil {
+			item.ControlPlaneStatus = types.StringValue(*c.ControlPlaneStatus)
+		} else {
+			item.ControlPlaneStatus = types.StringNull()
+		}
+
+		if c.Version != nil {
+			item.Version = types.StringValue(*c.Version)
+		} else {
+			item.Version = types.StringNull()
+		}
+
+		if c.DeploymentLocation != nil {
+			item.DeploymentLocation = types.StringValue(*c.DeploymentLocation)
+		} else {
+			item.DeploymentLocation = types.StringNull()
+		}
+
+		if c.K8sConnectionType != nil {
+			item.K8sConnectionType = types.StringValue(*c.K8sConnectionType)
+		} else {
+			item.K8sConnectionType = types.StringNull()
+		}
+
+		if c.DomainName != nil {
+			item.DomainName = types.StringValue(*c.DomainName)
+		} else {
+			item.DomainName = types.StringNull()
+		}
+
+		if c.CreatedAt != nil {
+			item.CreatedAt = types.StringValue(*c.CreatedAt)
+		} else {
+			item.CreatedAt = types.StringNull()
+		}
+
+		if c.CreatedByName != nil {
+			item.CreatedByName = types.StringValue(*c.CreatedByName)
+		} else {
+			item.CreatedByName = types.StringNull()
+		}
+
+		if c.CreatedById != nil {
+			item.CreatedById = types.Int64Value(int64(*c.CreatedById))
+		} else {
+			item.CreatedById = types.Int64Null()
+		}
+
+		if c.ModifiedAt != nil {
+			item.ModifiedAt = types.StringValue(*c.ModifiedAt)
+		} else {
+			item.ModifiedAt = types.StringNull()
+		}
+
+		if c.ModifiedByName != nil {
+			item.ModifiedByName = types.StringValue(*c.ModifiedByName)
+		} else {
+			item.ModifiedByName = types.StringNull()
+		}
+
+		if c.ModifiedById != nil {
+			item.ModifiedById = types.Int64Value(int64(*c.ModifiedById))
+		} else {
+			item.ModifiedById = types.Int64Null()
+		}
+
+		itemModels = append(itemModels, item)
+	}
+
+	clusterList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: kubernetesClusterItemModel{}.attrTypes()}, itemModels)
+	diags.Append(listDiags...)
+
+	return clusterList, diags
+}

--- a/internal/emma/provider.go
+++ b/internal/emma/provider.go
@@ -244,6 +244,9 @@ func (p *Provider) DataSources(_ context.Context) []func() datasource.DataSource
 		NewSystemVolumeConfigsDataSource,
 		NewKuberNodesConfigsDataSource,
 		NewVmResizeConfigsDataSource,
+		NewSshKeyDataSource,
+		NewStatisticalDataDataSource,
+		NewWorkflowTemplatesDataSource,
 	}
 }
 
@@ -257,6 +260,7 @@ func (p *Provider) Resources(_ context.Context) []func() resource.Resource {
 		NewKubernetesResource,
 		NewVolumeResource,
 		NewSubnetworkResource,
+		NewWorkflowTemplateResource,
 	}
 }
 

--- a/internal/emma/provider.go
+++ b/internal/emma/provider.go
@@ -232,6 +232,18 @@ func (p *Provider) DataSources(_ context.Context) []func() datasource.DataSource
 		NewMulticloudNetworkDataSource,
 		NewConnectivityCenterDataSource,
 		NewAcceleratorTypeDataSource,
+		NewAcceleratorTypesDataSource,
+		NewVmConfigurationsDataSource,
+		NewSpotConfigurationsDataSource,
+		NewVmsDataSource,
+		NewSpotsDataSource,
+		NewSecurityGroupsDataSource,
+		NewVolumesDataSource,
+		NewSshKeysDataSource,
+		NewKubernetesClustersDataSource,
+		NewSystemVolumeConfigsDataSource,
+		NewKuberNodesConfigsDataSource,
+		NewVmResizeConfigsDataSource,
 	}
 }
 

--- a/internal/emma/security_group_resource.go
+++ b/internal/emma/security_group_resource.go
@@ -560,13 +560,22 @@ func ConvertSecurityGroupResponseToResource(ctx context.Context, planData *secur
 		stateData.Name = planData.Name
 	} else if securityGroupResponse.Rules != nil {
 		var rules []securityGroupResourceRuleModel
-		rulesListValue, _ := stateData.Rules.ToListValue(ctx)
+		rulesListValue, listDiags := stateData.Rules.ToListValue(ctx)
+		diags.Append(listDiags...)
 		rulesListValue.ElementsAs(ctx, &rules, false)
-		ruleOrderMap := make(map[string]int)
+
+		// Build an ordered index: key -> position in the state slice.
+		// Using the state slice length (not map length) so indices are always valid.
+		ruleOrderMap := make(map[string]int, len(rules))
 		for idx, rule := range rules {
-			ruleOrderMap[rule.Direction.ValueString()+rule.Protocol.ValueString()+rule.Ports.ValueString()+rule.IpRange.ValueString()] = idx
+			key := rule.Direction.ValueString() + rule.Protocol.ValueString() + rule.Ports.ValueString() + rule.IpRange.ValueString()
+			ruleOrderMap[key] = idx
 		}
-		securityGroupRuleModels := make([]securityGroupResourceRuleModel, len(ruleOrderMap))
+
+		// slots mirrors the state slice; filled[i]=true means the API returned that rule.
+		slots := make([]*securityGroupResourceRuleModel, len(rules))
+		var appended []securityGroupResourceRuleModel
+
 		for _, securityGroupRule := range securityGroupResponse.Rules {
 			if securityGroupRule.IsMutable == nil || !*securityGroupRule.IsMutable {
 				continue
@@ -579,14 +588,24 @@ func ConvertSecurityGroupResponseToResource(ctx context.Context, planData *secur
 			}
 			// to save same order as in configuration we have map, and we have 2 different checks with subnet mask and without
 			if idx, ok := ruleOrderMap[*securityGroupRule.Direction+*securityGroupRule.Protocol+*securityGroupRule.Ports+*securityGroupRule.IpRange]; ok {
-				securityGroupRuleModels[idx] = securityGroupRuleModel
+				slots[idx] = &securityGroupRuleModel
 			} else if idx1, ok1 := ruleOrderMap[*securityGroupRule.Direction+*securityGroupRule.Protocol+*securityGroupRule.Ports+stripSubnetMask(*securityGroupRule.IpRange)]; ok1 {
 				securityGroupRuleModel.IpRange = types.StringValue(stripSubnetMask(securityGroupRuleModel.IpRange.ValueString()))
-				securityGroupRuleModels[idx1] = securityGroupRuleModel
+				slots[idx1] = &securityGroupRuleModel
 			} else {
-				securityGroupRuleModels = append(securityGroupRuleModels, securityGroupRuleModel)
+				appended = append(appended, securityGroupRuleModel)
 			}
 		}
+
+		// Collect matched state-ordered rules, skipping slots not returned by API (deleted server-side).
+		securityGroupRuleModels := make([]securityGroupResourceRuleModel, 0, len(rules)+len(appended))
+		for _, slot := range slots {
+			if slot != nil {
+				securityGroupRuleModels = append(securityGroupRuleModels, *slot)
+			}
+		}
+		securityGroupRuleModels = append(securityGroupRuleModels, appended...)
+
 		rulesListValue, rulesDiagnostic := types.ListValueFrom(ctx,
 			types.ObjectType{AttrTypes: securityGroupResourceRuleModel{}.attrTypes()}, securityGroupRuleModels)
 		stateData.Rules = rulesListValue

--- a/internal/emma/security_groups_data_source.go
+++ b/internal/emma/security_groups_data_source.go
@@ -156,7 +156,7 @@ func (o securityGroupItemModel) attrTypes() map[string]attr.Type {
 // convertSecurityGroupsToList converts Emma API security groups response to Terraform list
 func convertSecurityGroupsToList(ctx context.Context, securityGroups []emmaSdk.SecurityGroup) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var itemModels []securityGroupItemModel
+	itemModels := make([]securityGroupItemModel, 0, len(securityGroups))
 
 	for _, sg := range securityGroups {
 		item := securityGroupItemModel{}

--- a/internal/emma/security_groups_data_source.go
+++ b/internal/emma/security_groups_data_source.go
@@ -1,0 +1,213 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &securityGroupsDataSource{}
+
+func NewSecurityGroupsDataSource() datasource.DataSource {
+	return &securityGroupsDataSource{}
+}
+
+// securityGroupsDataSource defines the data source implementation.
+type securityGroupsDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// securityGroupsDataSourceModel describes the data source data model.
+type securityGroupsDataSourceModel struct {
+	ProjectId      types.Int64 `tfsdk:"project_id"`
+	SecurityGroups types.List  `tfsdk:"security_groups"`
+}
+
+// securityGroupItemModel describes individual security group items in the list.
+type securityGroupItemModel struct {
+	Id                    types.Int64  `tfsdk:"id"`
+	Name                  types.String `tfsdk:"name"`
+	CreatedAt             types.String `tfsdk:"created_at"`
+	CreatedByName         types.String `tfsdk:"created_by_name"`
+	ModifiedAt            types.String `tfsdk:"modified_at"`
+	SynchronizationStatus types.String `tfsdk:"synchronization_status"`
+	RecomposingStatus     types.String `tfsdk:"recomposing_status"`
+}
+
+func (d *securityGroupsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_security_groups"
+}
+
+func (d *securityGroupsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a list of security groups in the Emma platform. Optionally filter by project ID.",
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.Int64Attribute{
+				Description: "Project ID to filter security groups",
+				Optional:    true,
+			},
+			"security_groups": schema.ListNestedAttribute{
+				Description: "List of security groups",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.Int64Attribute{
+							Description: "ID of the security group",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "Name of the security group",
+							Computed:    true,
+						},
+						"created_at": schema.StringAttribute{
+							Description: "Date and time when the security group was created",
+							Computed:    true,
+						},
+						"created_by_name": schema.StringAttribute{
+							Description: "Name of the user who created the security group",
+							Computed:    true,
+						},
+						"modified_at": schema.StringAttribute{
+							Description: "Date and time when the security group was last modified",
+							Computed:    true,
+						},
+						"synchronization_status": schema.StringAttribute{
+							Description: "Synchronization status of the security group rules across providers",
+							Computed:    true,
+						},
+						"recomposing_status": schema.StringAttribute{
+							Description: "Recomposing status of the security group when new VMs are added",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *securityGroupsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *securityGroupsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data securityGroupsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	apiReq := d.apiClient.SecurityGroupsAPI.GetSecurityGroups(auth)
+	if !data.ProjectId.IsNull() {
+		apiReq = apiReq.ProjectId(int32(data.ProjectId.ValueInt64()))
+	}
+	securityGroups, response, err := apiReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read security groups, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	sgList, diags := convertSecurityGroupsToList(ctx, securityGroups)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.SecurityGroups = sgList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Helper function to get attribute types for security group nested object
+func (o securityGroupItemModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":                     types.Int64Type,
+		"name":                   types.StringType,
+		"created_at":             types.StringType,
+		"created_by_name":        types.StringType,
+		"modified_at":            types.StringType,
+		"synchronization_status": types.StringType,
+		"recomposing_status":     types.StringType,
+	}
+}
+
+// convertSecurityGroupsToList converts Emma API security groups response to Terraform list
+func convertSecurityGroupsToList(ctx context.Context, securityGroups []emmaSdk.SecurityGroup) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var itemModels []securityGroupItemModel
+
+	for _, sg := range securityGroups {
+		item := securityGroupItemModel{}
+
+		if sg.Id != nil {
+			item.Id = types.Int64Value(int64(*sg.Id))
+		} else {
+			item.Id = types.Int64Null()
+		}
+
+		if sg.Name != nil {
+			item.Name = types.StringValue(*sg.Name)
+		} else {
+			item.Name = types.StringNull()
+		}
+
+		if sg.CreatedAt != nil {
+			item.CreatedAt = types.StringValue(*sg.CreatedAt)
+		} else {
+			item.CreatedAt = types.StringNull()
+		}
+
+		if sg.CreatedByName != nil {
+			item.CreatedByName = types.StringValue(*sg.CreatedByName)
+		} else {
+			item.CreatedByName = types.StringNull()
+		}
+
+		if sg.ModifiedAt != nil {
+			item.ModifiedAt = types.StringValue(*sg.ModifiedAt)
+		} else {
+			item.ModifiedAt = types.StringNull()
+		}
+
+		if sg.SynchronizationStatus != nil {
+			item.SynchronizationStatus = types.StringValue(*sg.SynchronizationStatus)
+		} else {
+			item.SynchronizationStatus = types.StringNull()
+		}
+
+		if sg.RecomposingStatus != nil {
+			item.RecomposingStatus = types.StringValue(*sg.RecomposingStatus)
+		} else {
+			item.RecomposingStatus = types.StringNull()
+		}
+
+		itemModels = append(itemModels, item)
+	}
+
+	sgList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: securityGroupItemModel{}.attrTypes()}, itemModels)
+	diags.Append(listDiags...)
+
+	return sgList, diags
+}

--- a/internal/emma/spot_configurations_data_source.go
+++ b/internal/emma/spot_configurations_data_source.go
@@ -1,0 +1,462 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &spotConfigurationsDataSource{}
+
+func NewSpotConfigurationsDataSource() datasource.DataSource {
+	return &spotConfigurationsDataSource{}
+}
+
+// spotConfigurationsDataSource defines the data source implementation.
+type spotConfigurationsDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// spotConfigurationsDataSourceModel describes the data source data model.
+type spotConfigurationsDataSourceModel struct {
+	AcceleratorTypeId types.String  `tfsdk:"accelerator_type_id"`
+	DataCenterId      types.String  `tfsdk:"data_center_id"`
+	ProviderId        types.Int64   `tfsdk:"provider_id"`
+	VcpuType          types.String  `tfsdk:"vcpu_type"`
+	VcpuMin           types.Int64   `tfsdk:"vcpu_min"`
+	VcpuMax           types.Int64   `tfsdk:"vcpu_max"`
+	RamGbMin          types.Int64   `tfsdk:"ram_gb_min"`
+	RamGbMax          types.Int64   `tfsdk:"ram_gb_max"`
+	VolumeGbMin       types.Int64   `tfsdk:"volume_gb_min"`
+	VolumeGbMax       types.Int64   `tfsdk:"volume_gb_max"`
+	PriceMin          types.Float64 `tfsdk:"price_min"`
+	PriceMax          types.Float64 `tfsdk:"price_max"`
+	Configurations    types.List    `tfsdk:"configurations"`
+}
+
+// spotConfigurationModel describes individual configuration items in the list.
+type spotConfigurationModel struct {
+	ProviderId        types.Int64   `tfsdk:"provider_id"`
+	ProviderName      types.String  `tfsdk:"provider_name"`
+	LocationName      types.String  `tfsdk:"location_name"`
+	DataCenterId      types.String  `tfsdk:"data_center_id"`
+	DataCenterName    types.String  `tfsdk:"data_center_name"`
+	OsId              types.Int64   `tfsdk:"os_id"`
+	OsType            types.String  `tfsdk:"os_type"`
+	CloudNetworkTypes types.List    `tfsdk:"cloud_network_types"`
+	VcpuType          types.String  `tfsdk:"vcpu_type"`
+	Vcpu              types.Int64   `tfsdk:"vcpu"`
+	RamGb             types.Int64   `tfsdk:"ram_gb"`
+	VolumeGb          types.Int64   `tfsdk:"volume_gb"`
+	VolumeType        types.String  `tfsdk:"volume_type"`
+	AcceleratorTypeId types.String  `tfsdk:"accelerator_type_id"`
+	AcceleratorType   types.String  `tfsdk:"accelerator_type"`
+	Accelerators      types.Float64 `tfsdk:"accelerators"`
+	PricePerUnit      types.Float64 `tfsdk:"price_per_unit"`
+	PriceCurrency     types.String  `tfsdk:"price_currency"`
+	PriceUnit         types.String  `tfsdk:"price_unit"`
+}
+
+func (d *spotConfigurationsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_spot_configurations"
+}
+
+func (d *spotConfigurationsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source retrieves available configurations for spot instance creation in the Emma platform.\n\n" +
+			"Use this data source to discover valid spot instance types, hardware specs, and pricing information when planning spot deployments.",
+		Attributes: map[string]schema.Attribute{
+			"accelerator_type_id": schema.StringAttribute{
+				Description: "Filter by accelerator type ID",
+				Optional:    true,
+			},
+			"data_center_id": schema.StringAttribute{
+				Description: "Filter by data center ID",
+				Optional:    true,
+			},
+			"provider_id": schema.Int64Attribute{
+				Description: "Filter by cloud provider ID",
+				Optional:    true,
+			},
+			"vcpu_type": schema.StringAttribute{
+				Description: "Filter by vCPU type",
+				Optional:    true,
+			},
+			"vcpu_min": schema.Int64Attribute{
+				Description: "Filter by minimum number of vCPUs",
+				Optional:    true,
+			},
+			"vcpu_max": schema.Int64Attribute{
+				Description: "Filter by maximum number of vCPUs",
+				Optional:    true,
+			},
+			"ram_gb_min": schema.Int64Attribute{
+				Description: "Filter by minimum RAM in gigabytes",
+				Optional:    true,
+			},
+			"ram_gb_max": schema.Int64Attribute{
+				Description: "Filter by maximum RAM in gigabytes",
+				Optional:    true,
+			},
+			"volume_gb_min": schema.Int64Attribute{
+				Description: "Filter by minimum volume size in gigabytes",
+				Optional:    true,
+			},
+			"volume_gb_max": schema.Int64Attribute{
+				Description: "Filter by maximum volume size in gigabytes",
+				Optional:    true,
+			},
+			"price_min": schema.Float64Attribute{
+				Description: "Filter by minimum price per unit",
+				Optional:    true,
+			},
+			"price_max": schema.Float64Attribute{
+				Description: "Filter by maximum price per unit",
+				Optional:    true,
+			},
+			"configurations": schema.ListNestedAttribute{
+				Description: "List of available spot instance configurations",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"provider_id": schema.Int64Attribute{
+							Description: "ID of the cloud provider",
+							Computed:    true,
+						},
+						"provider_name": schema.StringAttribute{
+							Description: "Name of the cloud provider",
+							Computed:    true,
+						},
+						"location_name": schema.StringAttribute{
+							Description: "Location name (city or state)",
+							Computed:    true,
+						},
+						"data_center_id": schema.StringAttribute{
+							Description: "ID of the data center",
+							Computed:    true,
+						},
+						"data_center_name": schema.StringAttribute{
+							Description: "Name of the data center",
+							Computed:    true,
+						},
+						"os_id": schema.Int64Attribute{
+							Description: "ID of the operating system",
+							Computed:    true,
+						},
+						"os_type": schema.StringAttribute{
+							Description: "Type of the operating system",
+							Computed:    true,
+						},
+						"cloud_network_types": schema.ListAttribute{
+							Description: "List of cloud network types supported",
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+						"vcpu_type": schema.StringAttribute{
+							Description: "Type of virtual Central Processing Units (vCPUs)",
+							Computed:    true,
+						},
+						"vcpu": schema.Int64Attribute{
+							Description: "Number of virtual Central Processing Units (vCPUs)",
+							Computed:    true,
+						},
+						"ram_gb": schema.Int64Attribute{
+							Description: "Capacity of the RAM in gigabytes",
+							Computed:    true,
+						},
+						"volume_gb": schema.Int64Attribute{
+							Description: "Capacity of the volume in gigabytes",
+							Computed:    true,
+						},
+						"volume_type": schema.StringAttribute{
+							Description: "Volume type",
+							Computed:    true,
+						},
+						"accelerator_type_id": schema.StringAttribute{
+							Description: "Accelerator type ID",
+							Computed:    true,
+						},
+						"accelerator_type": schema.StringAttribute{
+							Description: "GPU accelerator type",
+							Computed:    true,
+						},
+						"accelerators": schema.Float64Attribute{
+							Description: "Quantity of GPU accelerators",
+							Computed:    true,
+						},
+						"price_per_unit": schema.Float64Attribute{
+							Description: "Cost for the price period",
+							Computed:    true,
+						},
+						"price_currency": schema.StringAttribute{
+							Description: "Currency of the cost",
+							Computed:    true,
+						},
+						"price_unit": schema.StringAttribute{
+							Description: "Cost period",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *spotConfigurationsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *spotConfigurationsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data spotConfigurationsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	apiReq := d.apiClient.ComputeInstancesConfigurationsAPI.GetSpotConfigs(auth)
+
+	if !data.AcceleratorTypeId.IsNull() && !data.AcceleratorTypeId.IsUnknown() {
+		apiReq = apiReq.AcceleratorTypeId(data.AcceleratorTypeId.ValueString())
+	}
+	if !data.DataCenterId.IsNull() && !data.DataCenterId.IsUnknown() {
+		apiReq = apiReq.DataCenterId(data.DataCenterId.ValueString())
+	}
+	if !data.ProviderId.IsNull() && !data.ProviderId.IsUnknown() {
+		apiReq = apiReq.ProviderId(int32(data.ProviderId.ValueInt64()))
+	}
+	if !data.VcpuType.IsNull() && !data.VcpuType.IsUnknown() {
+		apiReq = apiReq.VCpuType(data.VcpuType.ValueString())
+	}
+	if !data.VcpuMin.IsNull() && !data.VcpuMin.IsUnknown() {
+		apiReq = apiReq.VCpuMin(int32(data.VcpuMin.ValueInt64()))
+	}
+	if !data.VcpuMax.IsNull() && !data.VcpuMax.IsUnknown() {
+		apiReq = apiReq.VCpuMax(int32(data.VcpuMax.ValueInt64()))
+	}
+	if !data.RamGbMin.IsNull() && !data.RamGbMin.IsUnknown() {
+		apiReq = apiReq.RamGbMin(int32(data.RamGbMin.ValueInt64()))
+	}
+	if !data.RamGbMax.IsNull() && !data.RamGbMax.IsUnknown() {
+		apiReq = apiReq.RamGbMax(int32(data.RamGbMax.ValueInt64()))
+	}
+	if !data.VolumeGbMin.IsNull() && !data.VolumeGbMin.IsUnknown() {
+		apiReq = apiReq.VolumeGbMin(int32(data.VolumeGbMin.ValueInt64()))
+	}
+	if !data.VolumeGbMax.IsNull() && !data.VolumeGbMax.IsUnknown() {
+		apiReq = apiReq.VolumeGbMax(int32(data.VolumeGbMax.ValueInt64()))
+	}
+	if !data.PriceMin.IsNull() && !data.PriceMin.IsUnknown() {
+		apiReq = apiReq.PriceMin(float32(data.PriceMin.ValueFloat64()))
+	}
+	if !data.PriceMax.IsNull() && !data.PriceMax.IsUnknown() {
+		apiReq = apiReq.PriceMax(float32(data.PriceMax.ValueFloat64()))
+	}
+
+	apiReq = apiReq.Size(100)
+	configs, response, err := apiReq.Execute()
+
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read spot configurations, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	configList, diags := convertSpotConfigsToList(ctx, configs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Configurations = configList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (o spotConfigurationModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"provider_id":         types.Int64Type,
+		"provider_name":       types.StringType,
+		"location_name":       types.StringType,
+		"data_center_id":      types.StringType,
+		"data_center_name":    types.StringType,
+		"os_id":               types.Int64Type,
+		"os_type":             types.StringType,
+		"cloud_network_types": types.ListType{ElemType: types.StringType},
+		"vcpu_type":           types.StringType,
+		"vcpu":                types.Int64Type,
+		"ram_gb":              types.Int64Type,
+		"volume_gb":           types.Int64Type,
+		"volume_type":         types.StringType,
+		"accelerator_type_id": types.StringType,
+		"accelerator_type":    types.StringType,
+		"accelerators":        types.Float64Type,
+		"price_per_unit":      types.Float64Type,
+		"price_currency":      types.StringType,
+		"price_unit":          types.StringType,
+	}
+}
+
+func convertSpotConfigsToList(ctx context.Context, configs *emmaSdk.GetVmConfigs200Response) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var configModels []spotConfigurationModel
+
+	if configs == nil || configs.Content == nil {
+		emptyList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: spotConfigurationModel{}.attrTypes()}, []spotConfigurationModel{})
+		diags.Append(listDiags...)
+		return emptyList, diags
+	}
+
+	for _, config := range configs.Content {
+		configModel := spotConfigurationModel{}
+
+		if config.ProviderId != nil {
+			configModel.ProviderId = types.Int64Value(int64(*config.ProviderId))
+		} else {
+			configModel.ProviderId = types.Int64Null()
+		}
+
+		if config.ProviderName != nil {
+			configModel.ProviderName = types.StringValue(*config.ProviderName)
+		} else {
+			configModel.ProviderName = types.StringNull()
+		}
+
+		if config.LocationName != nil {
+			configModel.LocationName = types.StringValue(*config.LocationName)
+		} else {
+			configModel.LocationName = types.StringNull()
+		}
+
+		if config.DataCenterId != nil {
+			configModel.DataCenterId = types.StringValue(*config.DataCenterId)
+		} else {
+			configModel.DataCenterId = types.StringNull()
+		}
+
+		if config.DataCenterName != nil {
+			configModel.DataCenterName = types.StringValue(*config.DataCenterName)
+		} else {
+			configModel.DataCenterName = types.StringNull()
+		}
+
+		if config.OsId != nil {
+			configModel.OsId = types.Int64Value(int64(*config.OsId))
+		} else {
+			configModel.OsId = types.Int64Null()
+		}
+
+		if config.OsType != nil {
+			configModel.OsType = types.StringValue(*config.OsType)
+		} else {
+			configModel.OsType = types.StringNull()
+		}
+
+		cloudNetworkTypesList, listDiags := types.ListValueFrom(ctx, types.StringType, config.CloudNetworkTypes)
+		diags.Append(listDiags...)
+		configModel.CloudNetworkTypes = cloudNetworkTypesList
+
+		if config.VCpuType != nil {
+			configModel.VcpuType = types.StringValue(*config.VCpuType)
+		} else {
+			configModel.VcpuType = types.StringNull()
+		}
+
+		if config.VCpu != nil {
+			configModel.Vcpu = types.Int64Value(int64(*config.VCpu))
+		} else {
+			configModel.Vcpu = types.Int64Null()
+		}
+
+		if config.RamGb != nil {
+			configModel.RamGb = types.Int64Value(int64(*config.RamGb))
+		} else {
+			configModel.RamGb = types.Int64Null()
+		}
+
+		if config.VolumeGb != nil {
+			configModel.VolumeGb = types.Int64Value(int64(*config.VolumeGb))
+		} else {
+			configModel.VolumeGb = types.Int64Null()
+		}
+
+		if config.VolumeType != nil {
+			configModel.VolumeType = types.StringValue(*config.VolumeType)
+		} else {
+			configModel.VolumeType = types.StringNull()
+		}
+
+		if config.Accelerator != nil {
+			if config.Accelerator.AcceleratorTypeId != nil {
+				configModel.AcceleratorTypeId = types.StringValue(*config.Accelerator.AcceleratorTypeId)
+			} else {
+				configModel.AcceleratorTypeId = types.StringNull()
+			}
+			if config.Accelerator.AcceleratorType != nil {
+				configModel.AcceleratorType = types.StringValue(*config.Accelerator.AcceleratorType)
+			} else {
+				configModel.AcceleratorType = types.StringNull()
+			}
+			if config.Accelerator.Accelerators != nil {
+				configModel.Accelerators = types.Float64Value(float64(*config.Accelerator.Accelerators))
+			} else {
+				configModel.Accelerators = types.Float64Null()
+			}
+		} else {
+			configModel.AcceleratorTypeId = types.StringNull()
+			configModel.AcceleratorType = types.StringNull()
+			configModel.Accelerators = types.Float64Null()
+		}
+
+		if config.Cost != nil {
+			if config.Cost.PricePerUnit != nil {
+				configModel.PricePerUnit = types.Float64Value(float64(*config.Cost.PricePerUnit))
+			} else {
+				configModel.PricePerUnit = types.Float64Null()
+			}
+			if config.Cost.Currency != nil {
+				configModel.PriceCurrency = types.StringValue(*config.Cost.Currency)
+			} else {
+				configModel.PriceCurrency = types.StringNull()
+			}
+			if config.Cost.Unit != nil {
+				configModel.PriceUnit = types.StringValue(*config.Cost.Unit)
+			} else {
+				configModel.PriceUnit = types.StringNull()
+			}
+		} else {
+			configModel.PricePerUnit = types.Float64Null()
+			configModel.PriceCurrency = types.StringNull()
+			configModel.PriceUnit = types.StringNull()
+		}
+
+		configModels = append(configModels, configModel)
+	}
+
+	configList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: spotConfigurationModel{}.attrTypes()}, configModels)
+	diags.Append(listDiags...)
+
+	return configList, diags
+}

--- a/internal/emma/spot_instance_resource.go
+++ b/internal/emma/spot_instance_resource.go
@@ -556,13 +556,20 @@ func ConvertSpotInstanceResponseToResource(ctx context.Context, stateData *spotI
 	if spotInstance.Accelerator != nil {
 		if spotInstance.Accelerator.AcceleratorTypeId != nil {
 			stateData.AcceleratorTypeId = types.StringValue(*spotInstance.Accelerator.AcceleratorTypeId)
+		} else {
+			stateData.AcceleratorTypeId = types.StringNull()
 		}
 		if spotInstance.Accelerator.Accelerators != nil {
 			stateData.Accelerators = types.Float64Value(float64(*spotInstance.Accelerator.Accelerators))
+		} else {
+			stateData.Accelerators = types.Float64Null()
 		}
 	} else if planData != nil {
 		stateData.AcceleratorTypeId = planData.AcceleratorTypeId
 		stateData.Accelerators = planData.Accelerators
+	} else {
+		stateData.AcceleratorTypeId = types.StringNull()
+		stateData.Accelerators = types.Float64Null()
 	}
 }
 

--- a/internal/emma/spots_data_source.go
+++ b/internal/emma/spots_data_source.go
@@ -1,0 +1,361 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &spotsDataSource{}
+
+func NewSpotsDataSource() datasource.DataSource {
+	return &spotsDataSource{}
+}
+
+// spotsDataSource defines the data source implementation.
+type spotsDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// spotsDataSourceModel describes the data source data model.
+type spotsDataSourceModel struct {
+	ProjectId types.Int64 `tfsdk:"project_id"`
+	Spots     types.List  `tfsdk:"spots"`
+}
+
+// spotItemModel describes individual spot instance items in the list.
+type spotItemModel struct {
+	Id                types.Int64  `tfsdk:"id"`
+	Name              types.String `tfsdk:"name"`
+	Status            types.String `tfsdk:"status"`
+	ProjectId         types.Int64  `tfsdk:"project_id"`
+	ProviderId        types.Int64  `tfsdk:"provider_id"`
+	ProviderName      types.String `tfsdk:"provider_name"`
+	LocationId        types.Int64  `tfsdk:"location_id"`
+	LocationName      types.String `tfsdk:"location_name"`
+	DataCenterId      types.String `tfsdk:"data_center_id"`
+	DataCenterName    types.String `tfsdk:"data_center_name"`
+	OsId              types.Int64  `tfsdk:"os_id"`
+	OsType            types.String `tfsdk:"os_type"`
+	VCpu              types.Int64  `tfsdk:"vcpu"`
+	VCpuType          types.String `tfsdk:"vcpu_type"`
+	RamGb             types.Int64  `tfsdk:"ram_gb"`
+	CloudNetworkType  types.String `tfsdk:"cloud_network_type"`
+	AcceleratorType   types.String `tfsdk:"accelerator_type"`
+	CreatedAt         types.String `tfsdk:"created_at"`
+}
+
+func (d *spotsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_spots"
+}
+
+func (d *spotsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a list of spot instances in the Emma platform. Optionally filter by project ID.",
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.Int64Attribute{
+				Description: "Project ID to filter spot instances",
+				Optional:    true,
+			},
+			"spots": schema.ListNestedAttribute{
+				Description: "List of spot instances",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.Int64Attribute{
+							Description: "ID of the spot instance",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "Name of the spot instance",
+							Computed:    true,
+						},
+						"status": schema.StringAttribute{
+							Description: "Status of the spot instance",
+							Computed:    true,
+						},
+						"project_id": schema.Int64Attribute{
+							Description: "Project ID the spot instance belongs to",
+							Computed:    true,
+						},
+						"provider_id": schema.Int64Attribute{
+							Description: "ID of the cloud provider",
+							Computed:    true,
+						},
+						"provider_name": schema.StringAttribute{
+							Description: "Name of the cloud provider",
+							Computed:    true,
+						},
+						"location_id": schema.Int64Attribute{
+							Description: "ID of the data center location",
+							Computed:    true,
+						},
+						"location_name": schema.StringAttribute{
+							Description: "Name of the data center location",
+							Computed:    true,
+						},
+						"data_center_id": schema.StringAttribute{
+							Description: "ID of the data center",
+							Computed:    true,
+						},
+						"data_center_name": schema.StringAttribute{
+							Description: "Name of the data center",
+							Computed:    true,
+						},
+						"os_id": schema.Int64Attribute{
+							Description: "ID of the operating system",
+							Computed:    true,
+						},
+						"os_type": schema.StringAttribute{
+							Description: "Type of the operating system",
+							Computed:    true,
+						},
+						"vcpu": schema.Int64Attribute{
+							Description: "Number of virtual CPUs",
+							Computed:    true,
+						},
+						"vcpu_type": schema.StringAttribute{
+							Description: "Type of virtual CPUs (shared, standard, hpc)",
+							Computed:    true,
+						},
+						"ram_gb": schema.Int64Attribute{
+							Description: "RAM in gigabytes",
+							Computed:    true,
+						},
+						"cloud_network_type": schema.StringAttribute{
+							Description: "Cloud network type of the spot instance",
+							Computed:    true,
+						},
+						"accelerator_type": schema.StringAttribute{
+							Description: "GPU accelerator type name, if applicable",
+							Computed:    true,
+						},
+						"created_at": schema.StringAttribute{
+							Description: "Date and time when the spot instance was created",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *spotsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *spotsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data spotsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	apiReq := d.apiClient.SpotInstancesAPI.GetSpots(auth)
+	if !data.ProjectId.IsNull() {
+		apiReq = apiReq.ProjectId(int32(data.ProjectId.ValueInt64()))
+	}
+	spots, response, err := apiReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read spot instances, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	spotList, diags := convertSpotsToList(ctx, spots)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Spots = spotList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Helper function to get attribute types for spot instance nested object
+func (o spotItemModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":                 types.Int64Type,
+		"name":               types.StringType,
+		"status":             types.StringType,
+		"project_id":         types.Int64Type,
+		"provider_id":        types.Int64Type,
+		"provider_name":      types.StringType,
+		"location_id":        types.Int64Type,
+		"location_name":      types.StringType,
+		"data_center_id":     types.StringType,
+		"data_center_name":   types.StringType,
+		"os_id":              types.Int64Type,
+		"os_type":            types.StringType,
+		"vcpu":               types.Int64Type,
+		"vcpu_type":          types.StringType,
+		"ram_gb":             types.Int64Type,
+		"cloud_network_type": types.StringType,
+		"accelerator_type":   types.StringType,
+		"created_at":         types.StringType,
+	}
+}
+
+// convertSpotsToList converts Emma API spot instances response to Terraform list
+func convertSpotsToList(ctx context.Context, spots []emmaSdk.SpotVm) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var itemModels []spotItemModel
+
+	for _, spot := range spots {
+		item := spotItemModel{}
+
+		if spot.Id != nil {
+			item.Id = types.Int64Value(int64(*spot.Id))
+		} else {
+			item.Id = types.Int64Null()
+		}
+
+		if spot.Name != nil {
+			item.Name = types.StringValue(*spot.Name)
+		} else {
+			item.Name = types.StringNull()
+		}
+
+		if spot.Status != nil {
+			item.Status = types.StringValue(*spot.Status)
+		} else {
+			item.Status = types.StringNull()
+		}
+
+		if spot.ProjectId != nil {
+			item.ProjectId = types.Int64Value(int64(*spot.ProjectId))
+		} else {
+			item.ProjectId = types.Int64Null()
+		}
+
+		if spot.Provider != nil {
+			if spot.Provider.Id != nil {
+				item.ProviderId = types.Int64Value(int64(*spot.Provider.Id))
+			} else {
+				item.ProviderId = types.Int64Null()
+			}
+			if spot.Provider.Name != nil {
+				item.ProviderName = types.StringValue(*spot.Provider.Name)
+			} else {
+				item.ProviderName = types.StringNull()
+			}
+		} else {
+			item.ProviderId = types.Int64Null()
+			item.ProviderName = types.StringNull()
+		}
+
+		if spot.Location != nil {
+			if spot.Location.Id != nil {
+				item.LocationId = types.Int64Value(int64(*spot.Location.Id))
+			} else {
+				item.LocationId = types.Int64Null()
+			}
+			if spot.Location.Name != nil {
+				item.LocationName = types.StringValue(*spot.Location.Name)
+			} else {
+				item.LocationName = types.StringNull()
+			}
+		} else {
+			item.LocationId = types.Int64Null()
+			item.LocationName = types.StringNull()
+		}
+
+		if spot.DataCenter != nil {
+			if spot.DataCenter.Id != nil {
+				item.DataCenterId = types.StringValue(*spot.DataCenter.Id)
+			} else {
+				item.DataCenterId = types.StringNull()
+			}
+			if spot.DataCenter.Name != nil {
+				item.DataCenterName = types.StringValue(*spot.DataCenter.Name)
+			} else {
+				item.DataCenterName = types.StringNull()
+			}
+		} else {
+			item.DataCenterId = types.StringNull()
+			item.DataCenterName = types.StringNull()
+		}
+
+		if spot.Os != nil {
+			if spot.Os.Id != nil {
+				item.OsId = types.Int64Value(int64(*spot.Os.Id))
+			} else {
+				item.OsId = types.Int64Null()
+			}
+			if spot.Os.Type != nil {
+				item.OsType = types.StringValue(*spot.Os.Type)
+			} else {
+				item.OsType = types.StringNull()
+			}
+		} else {
+			item.OsId = types.Int64Null()
+			item.OsType = types.StringNull()
+		}
+
+		if spot.VCpu != nil {
+			item.VCpu = types.Int64Value(int64(*spot.VCpu))
+		} else {
+			item.VCpu = types.Int64Null()
+		}
+
+		if spot.VCpuType != nil {
+			item.VCpuType = types.StringValue(*spot.VCpuType)
+		} else {
+			item.VCpuType = types.StringNull()
+		}
+
+		if spot.RamGb != nil {
+			item.RamGb = types.Int64Value(int64(*spot.RamGb))
+		} else {
+			item.RamGb = types.Int64Null()
+		}
+
+		if spot.CloudNetworkType != nil {
+			item.CloudNetworkType = types.StringValue(*spot.CloudNetworkType)
+		} else {
+			item.CloudNetworkType = types.StringNull()
+		}
+
+		if spot.Accelerator != nil && spot.Accelerator.AcceleratorType != nil {
+			item.AcceleratorType = types.StringValue(*spot.Accelerator.AcceleratorType)
+		} else {
+			item.AcceleratorType = types.StringNull()
+		}
+
+		if spot.CreatedAt != nil {
+			item.CreatedAt = types.StringValue(*spot.CreatedAt)
+		} else {
+			item.CreatedAt = types.StringNull()
+		}
+
+		itemModels = append(itemModels, item)
+	}
+
+	spotList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: spotItemModel{}.attrTypes()}, itemModels)
+	diags.Append(listDiags...)
+
+	return spotList, diags
+}

--- a/internal/emma/spots_data_source.go
+++ b/internal/emma/spots_data_source.go
@@ -222,7 +222,7 @@ func (o spotItemModel) attrTypes() map[string]attr.Type {
 // convertSpotsToList converts Emma API spot instances response to Terraform list
 func convertSpotsToList(ctx context.Context, spots []emmaSdk.SpotVm) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var itemModels []spotItemModel
+	itemModels := make([]spotItemModel, 0, len(spots))
 
 	for _, spot := range spots {
 		item := spotItemModel{}

--- a/internal/emma/ssh_key_data_source.go
+++ b/internal/emma/ssh_key_data_source.go
@@ -1,0 +1,172 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &sshKeyDataSource{}
+
+func NewSshKeyDataSource() datasource.DataSource {
+	return &sshKeyDataSource{}
+}
+
+// sshKeyDataSource defines the data source implementation.
+type sshKeyDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// sshKeyDataSourceModel describes the data source data model.
+type sshKeyDataSourceModel struct {
+	Id            types.Int64  `tfsdk:"id"`
+	Name          types.String `tfsdk:"name"`
+	Key           types.String `tfsdk:"key"`
+	KeyType       types.String `tfsdk:"key_type"`
+	Fingerprint   types.String `tfsdk:"fingerprint"`
+	CreatedAt     types.String `tfsdk:"created_at"`
+	CreatedByName types.String `tfsdk:"created_by_name"`
+	CreatedById   types.Int64  `tfsdk:"created_by_id"`
+}
+
+func (d *sshKeyDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_ssh_key"
+}
+
+func (d *sshKeyDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides information about an SSH key by its ID.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.Int64Attribute{
+				Description: "SSH key ID",
+				Required:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "SSH key name",
+				Computed:    true,
+			},
+			"key": schema.StringAttribute{
+				Description: "SSH public key content",
+				Computed:    true,
+			},
+			"key_type": schema.StringAttribute{
+				Description: "SSH key type (RSA or ED25519)",
+				Computed:    true,
+			},
+			"fingerprint": schema.StringAttribute{
+				Description: "SSH key fingerprint",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "Date and time when the SSH key was created",
+				Computed:    true,
+			},
+			"created_by_name": schema.StringAttribute{
+				Description: "Name of the user who created the SSH key",
+				Computed:    true,
+			},
+			"created_by_id": schema.Int64Attribute{
+				Description: "ID of the user who created the SSH key",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *sshKeyDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *sshKeyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data sshKeyDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := int32(data.Id.ValueInt64())
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	sshKey, response, err := d.apiClient.SSHKeysAPI.GetSshKey(auth, id).Execute()
+
+	if err != nil {
+		if response != nil && response.StatusCode == http.StatusNotFound {
+			resp.Diagnostics.AddError("SSH key not found",
+				fmt.Sprintf("SSH key with id %d not found", id))
+		} else {
+			resp.Diagnostics.AddError("Client Error",
+				fmt.Sprintf("Unable to read SSH key, got error: %s",
+					tools.ExtractErrorMessage(response)))
+		}
+		return
+	}
+
+	if sshKey.Id != nil {
+		data.Id = types.Int64Value(int64(*sshKey.Id))
+	} else {
+		data.Id = types.Int64Null()
+	}
+
+	if sshKey.Name != nil {
+		data.Name = types.StringValue(*sshKey.Name)
+	} else {
+		data.Name = types.StringNull()
+	}
+
+	if sshKey.Key != nil {
+		data.Key = types.StringValue(*sshKey.Key)
+	} else {
+		data.Key = types.StringNull()
+	}
+
+	if sshKey.KeyType != nil {
+		data.KeyType = types.StringValue(*sshKey.KeyType)
+	} else {
+		data.KeyType = types.StringNull()
+	}
+
+	if sshKey.Fingerprint != nil {
+		data.Fingerprint = types.StringValue(*sshKey.Fingerprint)
+	} else {
+		data.Fingerprint = types.StringNull()
+	}
+
+	if sshKey.CreatedAt != nil {
+		data.CreatedAt = types.StringValue(*sshKey.CreatedAt)
+	} else {
+		data.CreatedAt = types.StringNull()
+	}
+
+	if sshKey.CreatedByName != nil {
+		data.CreatedByName = types.StringValue(*sshKey.CreatedByName)
+	} else {
+		data.CreatedByName = types.StringNull()
+	}
+
+	if sshKey.CreatedById != nil {
+		data.CreatedById = types.Int64Value(int64(*sshKey.CreatedById))
+	} else {
+		data.CreatedById = types.Int64Null()
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/emma/ssh_keys_data_source.go
+++ b/internal/emma/ssh_keys_data_source.go
@@ -1,0 +1,216 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &sshKeysDataSource{}
+
+func NewSshKeysDataSource() datasource.DataSource {
+	return &sshKeysDataSource{}
+}
+
+// sshKeysDataSource defines the data source implementation.
+type sshKeysDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// sshKeysDataSourceModel describes the data source data model.
+type sshKeysDataSourceModel struct {
+	SshKeys types.List `tfsdk:"ssh_keys"`
+}
+
+// sshKeyItemModel describes individual SSH key items in the list.
+type sshKeyItemModel struct {
+	Id            types.Int64  `tfsdk:"id"`
+	Name          types.String `tfsdk:"name"`
+	Key           types.String `tfsdk:"key"`
+	KeyType       types.String `tfsdk:"key_type"`
+	Fingerprint   types.String `tfsdk:"fingerprint"`
+	CreatedAt     types.String `tfsdk:"created_at"`
+	CreatedByName types.String `tfsdk:"created_by_name"`
+	CreatedById   types.Int64  `tfsdk:"created_by_id"`
+}
+
+func (d *sshKeysDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_ssh_keys"
+}
+
+func (d *sshKeysDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a list of all SSH keys in the project.",
+		Attributes: map[string]schema.Attribute{
+			"ssh_keys": schema.ListNestedAttribute{
+				Description: "List of SSH keys",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.Int64Attribute{
+							Description: "SSH key ID",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "SSH key name",
+							Computed:    true,
+						},
+						"key": schema.StringAttribute{
+							Description: "SSH public key content",
+							Computed:    true,
+						},
+						"key_type": schema.StringAttribute{
+							Description: "SSH key type (RSA or ED25519)",
+							Computed:    true,
+						},
+						"fingerprint": schema.StringAttribute{
+							Description: "SSH key fingerprint",
+							Computed:    true,
+						},
+						"created_at": schema.StringAttribute{
+							Description: "Date and time when the SSH key was created",
+							Computed:    true,
+						},
+						"created_by_name": schema.StringAttribute{
+							Description: "Name of the user who created the SSH key",
+							Computed:    true,
+						},
+						"created_by_id": schema.Int64Attribute{
+							Description: "ID of the user who created the SSH key",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *sshKeysDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *sshKeysDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data sshKeysDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	sshKeys, response, err := d.apiClient.SSHKeysAPI.SshKeys(auth).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read SSH keys, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	keyList, diags := convertSshKeysToList(ctx, sshKeys)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.SshKeys = keyList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Helper function to get attribute types for SSH key nested object
+func (o sshKeyItemModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":              types.Int64Type,
+		"name":            types.StringType,
+		"key":             types.StringType,
+		"key_type":        types.StringType,
+		"fingerprint":     types.StringType,
+		"created_at":      types.StringType,
+		"created_by_name": types.StringType,
+		"created_by_id":   types.Int64Type,
+	}
+}
+
+// convertSshKeysToList converts Emma API SSH keys response to Terraform list
+func convertSshKeysToList(ctx context.Context, sshKeys []emmaSdk.SshKey) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var itemModels []sshKeyItemModel
+
+	for _, k := range sshKeys {
+		item := sshKeyItemModel{}
+
+		if k.Id != nil {
+			item.Id = types.Int64Value(int64(*k.Id))
+		} else {
+			item.Id = types.Int64Null()
+		}
+
+		if k.Name != nil {
+			item.Name = types.StringValue(*k.Name)
+		} else {
+			item.Name = types.StringNull()
+		}
+
+		if k.Key != nil {
+			item.Key = types.StringValue(*k.Key)
+		} else {
+			item.Key = types.StringNull()
+		}
+
+		if k.KeyType != nil {
+			item.KeyType = types.StringValue(*k.KeyType)
+		} else {
+			item.KeyType = types.StringNull()
+		}
+
+		if k.Fingerprint != nil {
+			item.Fingerprint = types.StringValue(*k.Fingerprint)
+		} else {
+			item.Fingerprint = types.StringNull()
+		}
+
+		if k.CreatedAt != nil {
+			item.CreatedAt = types.StringValue(*k.CreatedAt)
+		} else {
+			item.CreatedAt = types.StringNull()
+		}
+
+		if k.CreatedByName != nil {
+			item.CreatedByName = types.StringValue(*k.CreatedByName)
+		} else {
+			item.CreatedByName = types.StringNull()
+		}
+
+		if k.CreatedById != nil {
+			item.CreatedById = types.Int64Value(int64(*k.CreatedById))
+		} else {
+			item.CreatedById = types.Int64Null()
+		}
+
+		itemModels = append(itemModels, item)
+	}
+
+	keyList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: sshKeyItemModel{}.attrTypes()}, itemModels)
+	diags.Append(listDiags...)
+
+	return keyList, diags
+}

--- a/internal/emma/ssh_keys_data_source.go
+++ b/internal/emma/ssh_keys_data_source.go
@@ -153,7 +153,7 @@ func (o sshKeyItemModel) attrTypes() map[string]attr.Type {
 // convertSshKeysToList converts Emma API SSH keys response to Terraform list
 func convertSshKeysToList(ctx context.Context, sshKeys []emmaSdk.SshKey) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var itemModels []sshKeyItemModel
+	itemModels := make([]sshKeyItemModel, 0, len(sshKeys))
 
 	for _, k := range sshKeys {
 		item := sshKeyItemModel{}

--- a/internal/emma/statistical_data_data_source.go
+++ b/internal/emma/statistical_data_data_source.go
@@ -1,0 +1,1868 @@
+package emma
+
+// Deprecated: This data source uses the Statistics API endpoint POST /v1/statistics/retrieve,
+// which was marked deprecated on 2026-05-13. It remains available for historical reports
+// until a replacement endpoint is provided.
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &statisticalDataDataSource{}
+
+func NewStatisticalDataDataSource() datasource.DataSource {
+	return &statisticalDataDataSource{}
+}
+
+// statisticalDataDataSource defines the data source implementation.
+type statisticalDataDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// ---------------------------------------------------------------------------
+// Top-level data model — exactly one query block should be set.
+// ---------------------------------------------------------------------------
+
+type statisticalDataDataSourceModel struct {
+	// Query variants (exactly one should be set)
+	KubernetesClusterChangingMetrics *k8sChangingMetricsQueryModel `tfsdk:"kubernetes_cluster_changing_metrics"`
+	KubernetesClusterCurrentState    *k8sCurrentStateQueryModel    `tfsdk:"kubernetes_cluster_current_state"`
+	KubernetesClusterMetrics         *k8sMetricsQueryModel         `tfsdk:"kubernetes_cluster_metrics"`
+	KubernetesClusterObjectStates    *k8sObjectStatesQueryModel    `tfsdk:"kubernetes_cluster_object_states"`
+	KubernetesClusterObjects         *k8sObjectsQueryModel         `tfsdk:"kubernetes_cluster_objects"`
+	ProductStatistics                *productStatisticsQueryModel  `tfsdk:"product_statistics"`
+	ProjectSummary                   *projectSummaryQueryModel     `tfsdk:"project_summary"`
+	ResourceAnalysis                 *resourceAnalysisQueryModel   `tfsdk:"resource_analysis"`
+	VmAnalytics                      *vmAnalyticsQueryModel        `tfsdk:"vm_analytics"`
+	VmMonitoring                     *vmMonitoringQueryModel       `tfsdk:"vm_monitoring"`
+
+	// Computed result blocks — only the one matching the query variant will be populated.
+	KubernetesClusterChangingMetricsResults types.List `tfsdk:"kubernetes_cluster_changing_metrics_results"`
+	KubernetesClusterCurrentStateResults    types.List `tfsdk:"kubernetes_cluster_current_state_results"`
+	KubernetesClusterMetricsResults         types.List `tfsdk:"kubernetes_cluster_metrics_results"`
+	KubernetesClusterObjectStatesResults    types.List `tfsdk:"kubernetes_cluster_object_states_results"`
+	KubernetesClusterObjectsResults         types.List `tfsdk:"kubernetes_cluster_objects_results"`
+	ProductStatisticsResults                types.List `tfsdk:"product_statistics_results"`
+	ProjectSummaryResults                   types.List `tfsdk:"project_summary_results"`
+	ResourceAnalysisResults                 types.List `tfsdk:"resource_analysis_results"`
+	VmAnalyticsResults                      types.List `tfsdk:"vm_analytics_results"`
+	VmMonitoringResults                     types.List `tfsdk:"vm_monitoring_results"`
+}
+
+// ---------------------------------------------------------------------------
+// Query input models
+// ---------------------------------------------------------------------------
+
+type k8sChangingMetricsQueryModel struct {
+	DatasetName   types.String                        `tfsdk:"dataset_name"`
+	CoreClusterId types.Int64                         `tfsdk:"core_cluster_id"`
+	Filters       *k8sChangingMetricsQueryFiltersModel `tfsdk:"filters"`
+}
+
+type k8sChangingMetricsQueryFiltersModel struct {
+	ObjectType                  types.String `tfsdk:"object_type"`
+	ObjectName                  types.String `tfsdk:"object_name"`
+	BreakdownLevel              types.String `tfsdk:"breakdown_level"`
+	ChangingMetrics             types.List   `tfsdk:"changing_metrics"`
+	Timespan                    types.String `tfsdk:"timespan"`
+	CustomFilterState           types.String `tfsdk:"custom_filter_state"`
+	CustomFilterAvgCpuRule      types.String `tfsdk:"custom_filter_avg_cpu_rule"`
+	CustomFilterAvgCpuValue     types.Float64 `tfsdk:"custom_filter_avg_cpu_value"`
+	CustomFilterAvgMemoryRule   types.String `tfsdk:"custom_filter_avg_memory_rule"`
+	CustomFilterAvgMemoryValue  types.Float64 `tfsdk:"custom_filter_avg_memory_value"`
+	CustomFilterAvgStorageRule  types.String `tfsdk:"custom_filter_avg_storage_rule"`
+	CustomFilterAvgStorageValue types.Float64 `tfsdk:"custom_filter_avg_storage_value"`
+	CustomFilterSubobjects      types.List   `tfsdk:"custom_filter_subobjects"`
+}
+
+type k8sCurrentStateQueryModel struct {
+	DatasetName   types.String                       `tfsdk:"dataset_name"`
+	CoreClusterId types.Int64                        `tfsdk:"core_cluster_id"`
+	Filters       *k8sCurrentStateQueryFiltersModel   `tfsdk:"filters"`
+}
+
+type k8sCurrentStateQueryFiltersModel struct {
+	ObjectType                  types.String `tfsdk:"object_type"`
+	ObjectName                  types.String `tfsdk:"object_name"`
+	BreakdownLevel              types.String `tfsdk:"breakdown_level"`
+	CurrentStateMetrics         types.List   `tfsdk:"current_state_metrics"`
+	CustomFilterState           types.String `tfsdk:"custom_filter_state"`
+	CustomFilterAvgCpuRule      types.String `tfsdk:"custom_filter_avg_cpu_rule"`
+	CustomFilterAvgCpuValue     types.Float64 `tfsdk:"custom_filter_avg_cpu_value"`
+	CustomFilterAvgMemoryRule   types.String `tfsdk:"custom_filter_avg_memory_rule"`
+	CustomFilterAvgMemoryValue  types.Float64 `tfsdk:"custom_filter_avg_memory_value"`
+	CustomFilterAvgStorageRule  types.String `tfsdk:"custom_filter_avg_storage_rule"`
+	CustomFilterAvgStorageValue types.Float64 `tfsdk:"custom_filter_avg_storage_value"`
+	CustomFilterSubobjects      types.List   `tfsdk:"custom_filter_subobjects"`
+}
+
+type k8sMetricsQueryModel struct {
+	DatasetName   types.String               `tfsdk:"dataset_name"`
+	CoreClusterId types.Int64                `tfsdk:"core_cluster_id"`
+	Filters       *k8sMetricsQueryFiltersModel `tfsdk:"filters"`
+}
+
+type k8sMetricsQueryFiltersModel struct {
+	ObjectType     types.String `tfsdk:"object_type"`
+	ObjectName     types.String `tfsdk:"object_name"`
+	BreakdownLevel types.String `tfsdk:"breakdown_level"`
+}
+
+type k8sObjectStatesQueryModel struct {
+	DatasetName   types.String                    `tfsdk:"dataset_name"`
+	CoreClusterId types.Int64                     `tfsdk:"core_cluster_id"`
+	Filters       *k8sObjectStatesQueryFiltersModel `tfsdk:"filters"`
+}
+
+type k8sObjectStatesQueryFiltersModel struct {
+	ObjectType          types.String `tfsdk:"object_type"`
+	ObjectName          types.String `tfsdk:"object_name"`
+	BreakdownLevel      types.String `tfsdk:"breakdown_level"`
+	ObjectStatesMetrics types.List   `tfsdk:"object_states_metrics"`
+}
+
+type k8sObjectsQueryModel struct {
+	DatasetName   types.String `tfsdk:"dataset_name"`
+	CoreClusterId types.Int64  `tfsdk:"core_cluster_id"`
+}
+
+type productStatisticsQueryModel struct {
+	DatasetName types.String                      `tfsdk:"dataset_name"`
+	Filters     *productStatisticsQueryFiltersModel `tfsdk:"filters"`
+}
+
+type productStatisticsQueryFiltersModel struct {
+	ServiceFilter types.String `tfsdk:"service_filter"`
+}
+
+type projectSummaryQueryModel struct {
+	DatasetName types.String `tfsdk:"dataset_name"`
+}
+
+type resourceAnalysisQueryModel struct {
+	DatasetName types.String                     `tfsdk:"dataset_name"`
+	Filters     *resourceAnalysisQueryFiltersModel `tfsdk:"filters"`
+}
+
+type resourceAnalysisQueryFiltersModel struct {
+	PeriodStart types.String `tfsdk:"period_start"`
+	PeriodEnd   types.String `tfsdk:"period_end"`
+}
+
+type vmAnalyticsQueryModel struct {
+	DatasetName types.String `tfsdk:"dataset_name"`
+	VmId        types.Int64  `tfsdk:"vm_id"`
+}
+
+type vmMonitoringQueryModel struct {
+	DatasetName types.String               `tfsdk:"dataset_name"`
+	VmId        types.Int64                `tfsdk:"vm_id"`
+	Filters     *vmMonitoringQueryFiltersModel `tfsdk:"filters"`
+}
+
+type vmMonitoringQueryFiltersModel struct {
+	Period types.String `tfsdk:"period"`
+}
+
+// ---------------------------------------------------------------------------
+// Result item models
+// ---------------------------------------------------------------------------
+
+type k8sChangingMetricsResultModel struct {
+	SubobjectName   types.String  `tfsdk:"subobject_name"`
+	MetricName      types.String  `tfsdk:"metric_name"`
+	UiMetricGroup   types.String  `tfsdk:"ui_metric_group"`
+	UiColorGroupId  types.Int64   `tfsdk:"ui_color_group_id"`
+	UiMetricName    types.String  `tfsdk:"ui_metric_name"`
+	HumanLabel      types.String  `tfsdk:"human_label"`
+	Timecodes       types.List    `tfsdk:"timecodes"`
+	LinechartValues types.List    `tfsdk:"linechart_values"`
+	TreemapValues   types.Float64 `tfsdk:"treemap_values"`
+}
+
+func (o k8sChangingMetricsResultModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"subobject_name":   types.StringType,
+		"metric_name":      types.StringType,
+		"ui_metric_group":  types.StringType,
+		"ui_color_group_id": types.Int64Type,
+		"ui_metric_name":   types.StringType,
+		"human_label":      types.StringType,
+		"timecodes":        types.ListType{ElemType: types.StringType},
+		"linechart_values": types.ListType{ElemType: types.Float64Type},
+		"treemap_values":   types.Float64Type,
+	}
+}
+
+type k8sCurrentStateResultModel struct {
+	SubobjectName  types.String  `tfsdk:"subobject_name"`
+	MetricName     types.String  `tfsdk:"metric_name"`
+	UiMetricGroup  types.String  `tfsdk:"ui_metric_group"`
+	UiColorGroupId types.Int64   `tfsdk:"ui_color_group_id"`
+	UiMetricName   types.String  `tfsdk:"ui_metric_name"`
+	Value          types.Float64 `tfsdk:"value"`
+}
+
+func (o k8sCurrentStateResultModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"subobject_name":   types.StringType,
+		"metric_name":      types.StringType,
+		"ui_metric_group":  types.StringType,
+		"ui_color_group_id": types.Int64Type,
+		"ui_metric_name":   types.StringType,
+		"value":            types.Float64Type,
+	}
+}
+
+type k8sMetricsResultModel struct {
+	MetricName    types.String `tfsdk:"metric_name"`
+	UiMetricGroup types.String `tfsdk:"ui_metric_group"`
+	UiMetricName  types.String `tfsdk:"ui_metric_name"`
+	BlockName     types.String `tfsdk:"block_name"`
+}
+
+func (o k8sMetricsResultModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"metric_name":    types.StringType,
+		"ui_metric_group": types.StringType,
+		"ui_metric_name": types.StringType,
+		"block_name":     types.StringType,
+	}
+}
+
+type k8sObjectStatesResultModel struct {
+	MetricName     types.String `tfsdk:"metric_name"`
+	UiMetricGroup  types.String `tfsdk:"ui_metric_group"`
+	UiColorGroupId types.List   `tfsdk:"ui_color_group_id"`
+	UiMetricName   types.String `tfsdk:"ui_metric_name"`
+	SubobjectName  types.String `tfsdk:"subobject_name"`
+	Value          types.List   `tfsdk:"value"`
+}
+
+func (o k8sObjectStatesResultModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"metric_name":      types.StringType,
+		"ui_metric_group":  types.StringType,
+		"ui_color_group_id": types.ListType{ElemType: types.Int64Type},
+		"ui_metric_name":   types.StringType,
+		"subobject_name":   types.StringType,
+		"value":            types.ListType{ElemType: types.StringType},
+	}
+}
+
+type k8sObjectsResultModel struct {
+	ObjectType types.String `tfsdk:"object_type"`
+	ObjectName types.String `tfsdk:"object_name"`
+}
+
+func (o k8sObjectsResultModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"object_type": types.StringType,
+		"object_name": types.StringType,
+	}
+}
+
+type productStatisticsResultModel struct {
+	Service          types.String  `tfsdk:"service"`
+	VmId             types.Int64   `tfsdk:"vm_id"`
+	VmName           types.String  `tfsdk:"vm_name"`
+	HeadProductId    types.Int64   `tfsdk:"head_product_id"`
+	HeadProductName  types.String  `tfsdk:"head_product_name"`
+	Currency         types.String  `tfsdk:"currency"`
+	Cost             types.Float64 `tfsdk:"cost"`
+	ProviderName     types.String  `tfsdk:"provider_name"`
+	Country          types.String  `tfsdk:"country"`
+	Location         types.String  `tfsdk:"location"`
+	Latitude         types.Float64 `tfsdk:"latitude"`
+	Longitude        types.Float64 `tfsdk:"longitude"`
+	StatusNormalized types.String  `tfsdk:"status_normalized"`
+	CpuTotal         types.Float64 `tfsdk:"cpu_total"`
+	RamTotal         types.Float64 `tfsdk:"ram_total"`
+	DiskUsageTotal   types.Float64 `tfsdk:"disk_usage_total"`
+	CpuUsage         types.Float64 `tfsdk:"cpu_usage"`
+	RamUsage         types.Float64 `tfsdk:"ram_usage"`
+	DiskUsage        types.Float64 `tfsdk:"disk_usage"`
+	EmptyValue       types.Int64   `tfsdk:"empty_value"`
+}
+
+func (o productStatisticsResultModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"service":           types.StringType,
+		"vm_id":             types.Int64Type,
+		"vm_name":           types.StringType,
+		"head_product_id":   types.Int64Type,
+		"head_product_name": types.StringType,
+		"currency":          types.StringType,
+		"cost":              types.Float64Type,
+		"provider_name":     types.StringType,
+		"country":           types.StringType,
+		"location":          types.StringType,
+		"latitude":          types.Float64Type,
+		"longitude":         types.Float64Type,
+		"status_normalized": types.StringType,
+		"cpu_total":         types.Float64Type,
+		"ram_total":         types.Float64Type,
+		"disk_usage_total":  types.Float64Type,
+		"cpu_usage":         types.Float64Type,
+		"ram_usage":         types.Float64Type,
+		"disk_usage":        types.Float64Type,
+		"empty_value":       types.Int64Type,
+	}
+}
+
+type projectSummaryResultModel struct {
+	Service          types.String  `tfsdk:"service"`
+	AllInstallations types.Int64   `tfsdk:"all_installations"`
+	Cost             types.Float64 `tfsdk:"cost"`
+}
+
+func (o projectSummaryResultModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"service":           types.StringType,
+		"all_installations": types.Int64Type,
+		"cost":              types.Float64Type,
+	}
+}
+
+type resourceAnalysisResultModel struct {
+	Service           types.String  `tfsdk:"service"`
+	Timecode          types.String  `tfsdk:"timecode"`
+	CpuCoresNumber    types.Float64 `tfsdk:"cpu_cores_number"`
+	RamTotalAmountGb  types.Float64 `tfsdk:"ram_total_amount_gb"`
+	DiskSpaceTotalGb  types.Float64 `tfsdk:"disk_space_total_gb"`
+	Type              types.String  `tfsdk:"type"`
+}
+
+func (o resourceAnalysisResultModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"service":             types.StringType,
+		"timecode":            types.StringType,
+		"cpu_cores_number":    types.Float64Type,
+		"ram_total_amount_gb": types.Float64Type,
+		"disk_space_total_gb": types.Float64Type,
+		"type":                types.StringType,
+	}
+}
+
+type vmAnalyticsResultModel struct {
+	VmId                          types.Int64   `tfsdk:"vm_id"`
+	Timecode                      types.String  `tfsdk:"timecode"`
+	AvgDateStart                  types.String  `tfsdk:"avg_date_start"`
+	AvgDateEnd                    types.String  `tfsdk:"avg_date_end"`
+	QuantilesDateStart            types.String  `tfsdk:"quantiles_date_start"`
+	QuantilesDateEnd              types.String  `tfsdk:"quantiles_date_end"`
+	CpuDataPresent                types.Int64   `tfsdk:"cpu_data_present"`
+	CpuUtilizationAverageCores    types.Float64 `tfsdk:"cpu_utilization_average_cores"`
+	CpuCoresNumber                types.Int64   `tfsdk:"cpu_cores_number"`
+	CpuTotalPercent               types.Int64   `tfsdk:"cpu_total_percent"`
+	CpuHumanLabel                 types.String  `tfsdk:"cpu_human_label"`
+	RamDataPresent                types.Int64   `tfsdk:"ram_data_present"`
+	RamUsageAverageMb             types.Float64 `tfsdk:"ram_usage_average_mb"`
+	RamTotalAmountMb              types.Int64   `tfsdk:"ram_total_amount_mb"`
+	RamHumanLabel                 types.String  `tfsdk:"ram_human_label"`
+	DiskUsedDataPresent           types.Int64   `tfsdk:"disk_used_data_present"`
+	DiskSpaceUsedGb               types.Float64 `tfsdk:"disk_space_used_gb"`
+	DiskSpaceTotalGb              types.Float64 `tfsdk:"disk_space_total_gb"`
+	DiskSpaceHumanLabel           types.String  `tfsdk:"disk_space_human_label"`
+	DiskWriteDataPresent          types.Int64   `tfsdk:"disk_write_data_present"`
+	DiskWriteBps                  types.Float64 `tfsdk:"disk_write_bps"`
+	DiskWriteHuman                types.Float64 `tfsdk:"disk_write_human"`
+	DiskWriteHumanLabel           types.String  `tfsdk:"disk_write_human_label"`
+	DiskReadDataPresent           types.Int64   `tfsdk:"disk_read_data_present"`
+	DiskReadBps                   types.Float64 `tfsdk:"disk_read_bps"`
+	DiskReadHuman                 types.Float64 `tfsdk:"disk_read_human"`
+	DiskReadHumanLabel            types.String  `tfsdk:"disk_read_human_label"`
+	NetworkOutDataPresent         types.Int64   `tfsdk:"network_out_data_present"`
+	NetworkOutBps                 types.Float64 `tfsdk:"network_out_bps"`
+	NetworkOutHuman               types.Float64 `tfsdk:"network_out_human"`
+	NetworkOutHumanLabel          types.String  `tfsdk:"network_out_human_label"`
+	NetworkInDataPresent          types.Int64   `tfsdk:"network_in_data_present"`
+	NetworkInBps                  types.Float64 `tfsdk:"network_in_bps"`
+	NetworkInHuman                types.Float64 `tfsdk:"network_in_human"`
+	NetworkInHumanLabel           types.String  `tfsdk:"network_in_human_label"`
+	GpuDataPresent                types.Int64   `tfsdk:"gpu_data_present"`
+	GpuUtilizationAvgPercent      types.Float64 `tfsdk:"gpu_utilization_avg_percent"`
+	GpuTotalPercent               types.Int64   `tfsdk:"gpu_total_percent"`
+	GpuHumanLabel                 types.String  `tfsdk:"gpu_human_label"`
+	GpuRamDataPresent             types.Int64   `tfsdk:"gpu_ram_data_present"`
+	GpuRamUsageAvgGb              types.Float64 `tfsdk:"gpu_ram_usage_avg_gb"`
+	GpuRamTotalGb                 types.Float64 `tfsdk:"gpu_ram_total_gb"`
+	GpuRamHumanLabel              types.String  `tfsdk:"gpu_ram_human_label"`
+	GpuRamUtilizationDataPresent  types.Int64   `tfsdk:"gpu_ram_utilization_data_present"`
+	GpuRamUtilizationAvgPercent   types.Float64 `tfsdk:"gpu_ram_utilization_avg_percent"`
+	GpuRamUtilizationTotalPercent types.Int64   `tfsdk:"gpu_ram_utilization_total_percent"`
+	GpuRamUtilizationHumanLabel   types.String  `tfsdk:"gpu_ram_utilization_human_label"`
+	IsShownShort                  types.Int64   `tfsdk:"is_shown_short"`
+	Type                          types.String  `tfsdk:"type"`
+}
+
+func (o vmAnalyticsResultModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"vm_id":                            types.Int64Type,
+		"timecode":                         types.StringType,
+		"avg_date_start":                   types.StringType,
+		"avg_date_end":                     types.StringType,
+		"quantiles_date_start":             types.StringType,
+		"quantiles_date_end":               types.StringType,
+		"cpu_data_present":                 types.Int64Type,
+		"cpu_utilization_average_cores":    types.Float64Type,
+		"cpu_cores_number":                 types.Int64Type,
+		"cpu_total_percent":                types.Int64Type,
+		"cpu_human_label":                  types.StringType,
+		"ram_data_present":                 types.Int64Type,
+		"ram_usage_average_mb":             types.Float64Type,
+		"ram_total_amount_mb":              types.Int64Type,
+		"ram_human_label":                  types.StringType,
+		"disk_used_data_present":           types.Int64Type,
+		"disk_space_used_gb":               types.Float64Type,
+		"disk_space_total_gb":              types.Float64Type,
+		"disk_space_human_label":           types.StringType,
+		"disk_write_data_present":          types.Int64Type,
+		"disk_write_bps":                   types.Float64Type,
+		"disk_write_human":                 types.Float64Type,
+		"disk_write_human_label":           types.StringType,
+		"disk_read_data_present":           types.Int64Type,
+		"disk_read_bps":                    types.Float64Type,
+		"disk_read_human":                  types.Float64Type,
+		"disk_read_human_label":            types.StringType,
+		"network_out_data_present":         types.Int64Type,
+		"network_out_bps":                  types.Float64Type,
+		"network_out_human":                types.Float64Type,
+		"network_out_human_label":          types.StringType,
+		"network_in_data_present":          types.Int64Type,
+		"network_in_bps":                   types.Float64Type,
+		"network_in_human":                 types.Float64Type,
+		"network_in_human_label":           types.StringType,
+		"gpu_data_present":                 types.Int64Type,
+		"gpu_utilization_avg_percent":      types.Float64Type,
+		"gpu_total_percent":                types.Int64Type,
+		"gpu_human_label":                  types.StringType,
+		"gpu_ram_data_present":             types.Int64Type,
+		"gpu_ram_usage_avg_gb":             types.Float64Type,
+		"gpu_ram_total_gb":                 types.Float64Type,
+		"gpu_ram_human_label":              types.StringType,
+		"gpu_ram_utilization_data_present": types.Int64Type,
+		"gpu_ram_utilization_avg_percent":  types.Float64Type,
+		"gpu_ram_utilization_total_percent": types.Int64Type,
+		"gpu_ram_utilization_human_label":  types.StringType,
+		"is_shown_short":                   types.Int64Type,
+		"type":                             types.StringType,
+	}
+}
+
+type vmMonitoringResultModel struct {
+	Timecode                        types.String  `tfsdk:"timecode"`
+	CpuDataPresent                  types.Int64   `tfsdk:"cpu_data_present"`
+	CpuUtilizationAverageCores      types.Float64 `tfsdk:"cpu_utilization_average_cores"`
+	AvgCpuUtilizationAverageCores   types.Float64 `tfsdk:"avg_cpu_utilization_average_cores"`
+	MaxCpuUtilizationAverageCores   types.Float64 `tfsdk:"max_cpu_utilization_average_cores"`
+	CpuTotalPercent                 types.Int64   `tfsdk:"cpu_total_percent"`
+	CpuHumanLabel                   types.String  `tfsdk:"cpu_human_label"`
+	RamDataPresent                  types.Int64   `tfsdk:"ram_data_present"`
+	RamUsageAverageGb               types.Float64 `tfsdk:"ram_usage_average_gb"`
+	AvgRamUsageAverageGb            types.Float64 `tfsdk:"avg_ram_usage_average_gb"`
+	MaxRamUsageAverageGb            types.Float64 `tfsdk:"max_ram_usage_average_gb"`
+	RamTotalAmountGb                types.Float64 `tfsdk:"ram_total_amount_gb"`
+	RamHumanLabel                   types.String  `tfsdk:"ram_human_label"`
+	DiskUsedDataPresent             types.Int64   `tfsdk:"disk_used_data_present"`
+	DiskSpaceUsedGb                 types.Float64 `tfsdk:"disk_space_used_gb"`
+	AvgDiskSpaceUsedGb              types.Float64 `tfsdk:"avg_disk_space_used_gb"`
+	MaxDiskSpaceUsedGb              types.Float64 `tfsdk:"max_disk_space_used_gb"`
+	DiskSpaceTotalGb                types.Int64   `tfsdk:"disk_space_total_gb"`
+	DiskSpaceHumanLabel             types.String  `tfsdk:"disk_space_human_label"`
+	DiskWriteDataPresent            types.Int64   `tfsdk:"disk_write_data_present"`
+	DiskWriteCoef                   types.Float64 `tfsdk:"disk_write_coef"`
+	DiskWriteHuman                  types.Float64 `tfsdk:"disk_write_human"`
+	AvgDiskWriteHuman               types.Float64 `tfsdk:"avg_disk_write_human"`
+	MaxDiskWriteHuman               types.Float64 `tfsdk:"max_disk_write_human"`
+	DiskWriteHumanLabel             types.String  `tfsdk:"disk_write_human_label"`
+	DiskReadDataPresent             types.Int64   `tfsdk:"disk_read_data_present"`
+	DiskReadCoef                    types.Float64 `tfsdk:"disk_read_coef"`
+	DiskReadHuman                   types.Float64 `tfsdk:"disk_read_human"`
+	AvgDiskReadHuman                types.Float64 `tfsdk:"avg_disk_read_human"`
+	MaxDiskReadHuman                types.Float64 `tfsdk:"max_disk_read_human"`
+	DiskReadHumanLabel              types.String  `tfsdk:"disk_read_human_label"`
+	NetworkOutDataPresent           types.Int64   `tfsdk:"network_out_data_present"`
+	NetworkOutCoef                  types.Float64 `tfsdk:"network_out_coef"`
+	NetworkOutHuman                 types.Float64 `tfsdk:"network_out_human"`
+	AvgNetworkOutHuman              types.Float64 `tfsdk:"avg_network_out_human"`
+	MaxNetworkOutHuman              types.Float64 `tfsdk:"max_network_out_human"`
+	NetworkOutHumanLabel            types.String  `tfsdk:"network_out_human_label"`
+	NetworkInDataPresent            types.Int64   `tfsdk:"network_in_data_present"`
+	NetworkInCoef                   types.Float64 `tfsdk:"network_in_coef"`
+	NetworkInHuman                  types.Float64 `tfsdk:"network_in_human"`
+	AvgNetworkInHuman               types.Float64 `tfsdk:"avg_network_in_human"`
+	MaxNetworkInHuman               types.Float64 `tfsdk:"max_network_in_human"`
+	NetworkInHumanLabel             types.String  `tfsdk:"network_in_human_label"`
+	GpuRamUsageDataPresent          types.Int64   `tfsdk:"gpu_ram_usage_data_present"`
+	GpuRamUsageAvgGb                types.Float64 `tfsdk:"gpu_ram_usage_avg_gb"`
+	AvgGpuRamUsageAvgGb             types.Float64 `tfsdk:"avg_gpu_ram_usage_avg_gb"`
+	MaxGpuRamUsageAvgGb             types.Float64 `tfsdk:"max_gpu_ram_usage_avg_gb"`
+	GpuRamUsageHumanLabel           types.String  `tfsdk:"gpu_ram_usage_human_label"`
+	GpuRamUtilizationAvgPresent     types.Int64   `tfsdk:"gpu_ram_utilization_avg_present"`
+	GpuRamUtilizationAvgPercent     types.Float64 `tfsdk:"gpu_ram_utilization_avg_percent"`
+	AvgGpuRamUtilizationAvgPercent  types.Float64 `tfsdk:"avg_gpu_ram_utilization_avg_percent"`
+	MaxGpuRamUtilizationAvgPercent  types.Float64 `tfsdk:"max_gpu_ram_utilization_avg_percent"`
+	GpuRamUtilizationHumanLabel     types.String  `tfsdk:"gpu_ram_utilization_human_label"`
+	GpuUtilizationDataPresent       types.Int64   `tfsdk:"gpu_utilization_data_present"`
+	GpuUtilizationAvgPercent        types.Float64 `tfsdk:"gpu_utilization_avg_percent"`
+	AvgGpuUtilizationAvgPercent     types.Float64 `tfsdk:"avg_gpu_utilization_avg_percent"`
+	MaxGpuUtilizationAvgPercent     types.Float64 `tfsdk:"max_gpu_utilization_avg_percent"`
+	GpuUtilizationHumanLabel        types.String  `tfsdk:"gpu_utilization_human_label"`
+}
+
+func (o vmMonitoringResultModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"timecode":                          types.StringType,
+		"cpu_data_present":                  types.Int64Type,
+		"cpu_utilization_average_cores":     types.Float64Type,
+		"avg_cpu_utilization_average_cores": types.Float64Type,
+		"max_cpu_utilization_average_cores": types.Float64Type,
+		"cpu_total_percent":                 types.Int64Type,
+		"cpu_human_label":                   types.StringType,
+		"ram_data_present":                  types.Int64Type,
+		"ram_usage_average_gb":              types.Float64Type,
+		"avg_ram_usage_average_gb":          types.Float64Type,
+		"max_ram_usage_average_gb":          types.Float64Type,
+		"ram_total_amount_gb":               types.Float64Type,
+		"ram_human_label":                   types.StringType,
+		"disk_used_data_present":            types.Int64Type,
+		"disk_space_used_gb":                types.Float64Type,
+		"avg_disk_space_used_gb":            types.Float64Type,
+		"max_disk_space_used_gb":            types.Float64Type,
+		"disk_space_total_gb":               types.Int64Type,
+		"disk_space_human_label":            types.StringType,
+		"disk_write_data_present":           types.Int64Type,
+		"disk_write_coef":                   types.Float64Type,
+		"disk_write_human":                  types.Float64Type,
+		"avg_disk_write_human":              types.Float64Type,
+		"max_disk_write_human":              types.Float64Type,
+		"disk_write_human_label":            types.StringType,
+		"disk_read_data_present":            types.Int64Type,
+		"disk_read_coef":                    types.Float64Type,
+		"disk_read_human":                   types.Float64Type,
+		"avg_disk_read_human":               types.Float64Type,
+		"max_disk_read_human":               types.Float64Type,
+		"disk_read_human_label":             types.StringType,
+		"network_out_data_present":          types.Int64Type,
+		"network_out_coef":                  types.Float64Type,
+		"network_out_human":                 types.Float64Type,
+		"avg_network_out_human":             types.Float64Type,
+		"max_network_out_human":             types.Float64Type,
+		"network_out_human_label":           types.StringType,
+		"network_in_data_present":           types.Int64Type,
+		"network_in_coef":                   types.Float64Type,
+		"network_in_human":                  types.Float64Type,
+		"avg_network_in_human":              types.Float64Type,
+		"max_network_in_human":              types.Float64Type,
+		"network_in_human_label":            types.StringType,
+		"gpu_ram_usage_data_present":        types.Int64Type,
+		"gpu_ram_usage_avg_gb":              types.Float64Type,
+		"avg_gpu_ram_usage_avg_gb":          types.Float64Type,
+		"max_gpu_ram_usage_avg_gb":          types.Float64Type,
+		"gpu_ram_usage_human_label":         types.StringType,
+		"gpu_ram_utilization_avg_present":   types.Int64Type,
+		"gpu_ram_utilization_avg_percent":   types.Float64Type,
+		"avg_gpu_ram_utilization_avg_percent": types.Float64Type,
+		"max_gpu_ram_utilization_avg_percent": types.Float64Type,
+		"gpu_ram_utilization_human_label":   types.StringType,
+		"gpu_utilization_data_present":      types.Int64Type,
+		"gpu_utilization_avg_percent":       types.Float64Type,
+		"avg_gpu_utilization_avg_percent":   types.Float64Type,
+		"max_gpu_utilization_avg_percent":   types.Float64Type,
+		"gpu_utilization_human_label":       types.StringType,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+func (d *statisticalDataDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_statistical_data"
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+func (d *statisticalDataDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		DeprecationMessage: "The underlying API endpoint POST /v1/statistics/retrieve was deprecated on 2026-05-13. " +
+			"Use this data source only for historical reporting until a replacement becomes available.",
+		Description: "Fetches statistical data from emma's DWH. Exactly one query block must be configured. " +
+			"The corresponding result list attribute will be populated in state.\n\n" +
+			"DEPRECATED: The underlying API endpoint was deprecated on 2026-05-13.",
+		Attributes: map[string]schema.Attribute{
+			// ---- query inputs ----
+			"kubernetes_cluster_changing_metrics": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Query for Kubernetes cluster changing metrics over time.",
+				Attributes: map[string]schema.Attribute{
+					"dataset_name":    schema.StringAttribute{Required: true, Description: "Dataset name identifier."},
+					"core_cluster_id": schema.Int64Attribute{Required: true, Description: "Core cluster ID."},
+					"filters": schema.SingleNestedAttribute{
+						Required:    true,
+						Description: "Filter parameters for the query.",
+						Attributes: map[string]schema.Attribute{
+							"object_type":                    schema.StringAttribute{Required: true, Description: "Object type to filter."},
+							"object_name":                    schema.StringAttribute{Required: true, Description: "Object name to filter."},
+							"breakdown_level":                schema.StringAttribute{Required: true, Description: "Breakdown level."},
+							"changing_metrics":               schema.ListAttribute{Required: true, ElementType: types.StringType, Description: "List of changing metric names."},
+							"timespan":                       schema.StringAttribute{Required: true, Description: "Timespan for the query."},
+							"custom_filter_state":            schema.StringAttribute{Required: true, Description: "Custom filter state."},
+							"custom_filter_avg_cpu_rule":     schema.StringAttribute{Optional: true, Description: "Custom CPU filter rule (nullable)."},
+							"custom_filter_avg_cpu_value":    schema.Float64Attribute{Required: true, Description: "Custom CPU filter value."},
+							"custom_filter_avg_memory_rule":  schema.StringAttribute{Required: true, Description: "Custom memory filter rule."},
+							"custom_filter_avg_memory_value": schema.Float64Attribute{Required: true, Description: "Custom memory filter value."},
+							"custom_filter_avg_storage_rule":  schema.StringAttribute{Required: true, Description: "Custom storage filter rule."},
+							"custom_filter_avg_storage_value": schema.Float64Attribute{Required: true, Description: "Custom storage filter value."},
+							"custom_filter_subobjects":        schema.ListAttribute{Required: true, ElementType: types.StringType, Description: "List of subobjects to filter."},
+						},
+					},
+				},
+			},
+			"kubernetes_cluster_current_state": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Query for current state of Kubernetes cluster objects.",
+				Attributes: map[string]schema.Attribute{
+					"dataset_name":    schema.StringAttribute{Required: true, Description: "Dataset name identifier."},
+					"core_cluster_id": schema.Int64Attribute{Required: true, Description: "Core cluster ID."},
+					"filters": schema.SingleNestedAttribute{
+						Required:    true,
+						Description: "Filter parameters for the query.",
+						Attributes: map[string]schema.Attribute{
+							"object_type":                    schema.StringAttribute{Required: true, Description: "Object type to filter."},
+							"object_name":                    schema.StringAttribute{Required: true, Description: "Object name to filter."},
+							"breakdown_level":                schema.StringAttribute{Required: true, Description: "Breakdown level."},
+							"current_state_metrics":          schema.ListAttribute{Required: true, ElementType: types.StringType, Description: "List of current state metric names."},
+							"custom_filter_state":            schema.StringAttribute{Required: true, Description: "Custom filter state."},
+							"custom_filter_avg_cpu_rule":     schema.StringAttribute{Optional: true, Description: "Custom CPU filter rule (nullable)."},
+							"custom_filter_avg_cpu_value":    schema.Float64Attribute{Required: true, Description: "Custom CPU filter value."},
+							"custom_filter_avg_memory_rule":  schema.StringAttribute{Required: true, Description: "Custom memory filter rule."},
+							"custom_filter_avg_memory_value": schema.Float64Attribute{Required: true, Description: "Custom memory filter value."},
+							"custom_filter_avg_storage_rule":  schema.StringAttribute{Required: true, Description: "Custom storage filter rule."},
+							"custom_filter_avg_storage_value": schema.Float64Attribute{Required: true, Description: "Custom storage filter value."},
+							"custom_filter_subobjects":        schema.ListAttribute{Required: true, ElementType: types.StringType, Description: "List of subobjects to filter."},
+						},
+					},
+				},
+			},
+			"kubernetes_cluster_metrics": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Query for Kubernetes cluster metric definitions.",
+				Attributes: map[string]schema.Attribute{
+					"dataset_name":    schema.StringAttribute{Required: true, Description: "Dataset name identifier."},
+					"core_cluster_id": schema.Int64Attribute{Required: true, Description: "Core cluster ID."},
+					"filters": schema.SingleNestedAttribute{
+						Required:    true,
+						Description: "Filter parameters for the query.",
+						Attributes: map[string]schema.Attribute{
+							"object_type":    schema.StringAttribute{Required: true, Description: "Object type to filter."},
+							"object_name":    schema.StringAttribute{Required: true, Description: "Object name to filter."},
+							"breakdown_level": schema.StringAttribute{Required: true, Description: "Breakdown level."},
+						},
+					},
+				},
+			},
+			"kubernetes_cluster_object_states": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Query for Kubernetes cluster object state distributions.",
+				Attributes: map[string]schema.Attribute{
+					"dataset_name":    schema.StringAttribute{Required: true, Description: "Dataset name identifier."},
+					"core_cluster_id": schema.Int64Attribute{Required: true, Description: "Core cluster ID."},
+					"filters": schema.SingleNestedAttribute{
+						Required:    true,
+						Description: "Filter parameters for the query.",
+						Attributes: map[string]schema.Attribute{
+							"object_type":          schema.StringAttribute{Required: true, Description: "Object type to filter."},
+							"object_name":          schema.StringAttribute{Required: true, Description: "Object name to filter."},
+							"breakdown_level":      schema.StringAttribute{Required: true, Description: "Breakdown level."},
+							"object_states_metrics": schema.ListAttribute{Required: true, ElementType: types.StringType, Description: "List of object state metric names."},
+						},
+					},
+				},
+			},
+			"kubernetes_cluster_objects": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Query for Kubernetes cluster object inventory.",
+				Attributes: map[string]schema.Attribute{
+					"dataset_name":    schema.StringAttribute{Required: true, Description: "Dataset name identifier."},
+					"core_cluster_id": schema.Int64Attribute{Required: true, Description: "Core cluster ID."},
+				},
+			},
+			"product_statistics": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Query for product-level usage and cost statistics.",
+				Attributes: map[string]schema.Attribute{
+					"dataset_name": schema.StringAttribute{Required: true, Description: "Dataset name identifier."},
+					"filters": schema.SingleNestedAttribute{
+						Required:    true,
+						Description: "Filter parameters for the query.",
+						Attributes: map[string]schema.Attribute{
+							"service_filter": schema.StringAttribute{Required: true, Description: "Service name filter."},
+						},
+					},
+				},
+			},
+			"project_summary": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Query for project-level cost and usage summary.",
+				Attributes: map[string]schema.Attribute{
+					"dataset_name": schema.StringAttribute{Required: true, Description: "Dataset name identifier."},
+				},
+			},
+			"resource_analysis": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Query for resource analysis over a time period.",
+				Attributes: map[string]schema.Attribute{
+					"dataset_name": schema.StringAttribute{Required: true, Description: "Dataset name identifier."},
+					"filters": schema.SingleNestedAttribute{
+						Required:    true,
+						Description: "Filter parameters for the query.",
+						Attributes: map[string]schema.Attribute{
+							"period_start": schema.StringAttribute{Required: true, Description: "Start of the analysis period (ISO 8601)."},
+							"period_end":   schema.StringAttribute{Required: true, Description: "End of the analysis period (ISO 8601)."},
+						},
+					},
+				},
+			},
+			"vm_analytics": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Query for VM-level analytics and utilization statistics.",
+				Attributes: map[string]schema.Attribute{
+					"dataset_name": schema.StringAttribute{Required: true, Description: "Dataset name identifier."},
+					"vm_id":        schema.Int64Attribute{Required: true, Description: "ID of the virtual machine."},
+				},
+			},
+			"vm_monitoring": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Query for VM monitoring time-series data.",
+				Attributes: map[string]schema.Attribute{
+					"dataset_name": schema.StringAttribute{Required: true, Description: "Dataset name identifier."},
+					"vm_id":        schema.Int64Attribute{Required: true, Description: "ID of the virtual machine."},
+					"filters": schema.SingleNestedAttribute{
+						Required:    true,
+						Description: "Filter parameters for the query.",
+						Attributes: map[string]schema.Attribute{
+							"period": schema.StringAttribute{Required: true, Description: "Monitoring period (e.g. '1h', '24h', '7d')."},
+						},
+					},
+				},
+			},
+
+			// ---- computed results ----
+			"kubernetes_cluster_changing_metrics_results": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Results when kubernetes_cluster_changing_metrics query is used.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"subobject_name":   schema.StringAttribute{Computed: true, Description: "Subobject name."},
+						"metric_name":      schema.StringAttribute{Computed: true, Description: "Metric name."},
+						"ui_metric_group":  schema.StringAttribute{Computed: true, Description: "UI metric group."},
+						"ui_color_group_id": schema.Int64Attribute{Computed: true, Description: "UI color group ID."},
+						"ui_metric_name":   schema.StringAttribute{Computed: true, Description: "UI display name for the metric."},
+						"human_label":      schema.StringAttribute{Computed: true, Description: "Human-readable label."},
+						"timecodes":        schema.ListAttribute{Computed: true, ElementType: types.StringType, Description: "List of timecodes."},
+						"linechart_values": schema.ListAttribute{Computed: true, ElementType: types.Float64Type, Description: "Values for line chart."},
+						"treemap_values":   schema.Float64Attribute{Computed: true, Description: "Value for treemap visualization."},
+					},
+				},
+			},
+			"kubernetes_cluster_current_state_results": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Results when kubernetes_cluster_current_state query is used.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"subobject_name":   schema.StringAttribute{Computed: true, Description: "Subobject name."},
+						"metric_name":      schema.StringAttribute{Computed: true, Description: "Metric name."},
+						"ui_metric_group":  schema.StringAttribute{Computed: true, Description: "UI metric group."},
+						"ui_color_group_id": schema.Int64Attribute{Computed: true, Description: "UI color group ID."},
+						"ui_metric_name":   schema.StringAttribute{Computed: true, Description: "UI display name for the metric."},
+						"value":            schema.Float64Attribute{Computed: true, Description: "Current state metric value."},
+					},
+				},
+			},
+			"kubernetes_cluster_metrics_results": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Results when kubernetes_cluster_metrics query is used.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"metric_name":    schema.StringAttribute{Computed: true, Description: "Metric name."},
+						"ui_metric_group": schema.StringAttribute{Computed: true, Description: "UI metric group."},
+						"ui_metric_name": schema.StringAttribute{Computed: true, Description: "UI display name for the metric."},
+						"block_name":     schema.StringAttribute{Computed: true, Description: "UI block name."},
+					},
+				},
+			},
+			"kubernetes_cluster_object_states_results": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Results when kubernetes_cluster_object_states query is used.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"metric_name":      schema.StringAttribute{Computed: true, Description: "Metric name."},
+						"ui_metric_group":  schema.StringAttribute{Computed: true, Description: "UI metric group."},
+						"ui_color_group_id": schema.ListAttribute{Computed: true, ElementType: types.Int64Type, Description: "UI color group IDs."},
+						"ui_metric_name":   schema.StringAttribute{Computed: true, Description: "UI display name for the metric."},
+						"subobject_name":   schema.StringAttribute{Computed: true, Description: "Subobject name."},
+						"value":            schema.ListAttribute{Computed: true, ElementType: types.StringType, Description: "State values."},
+					},
+				},
+			},
+			"kubernetes_cluster_objects_results": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Results when kubernetes_cluster_objects query is used.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"object_type": schema.StringAttribute{Computed: true, Description: "Type of the Kubernetes object."},
+						"object_name": schema.StringAttribute{Computed: true, Description: "Name of the Kubernetes object."},
+					},
+				},
+			},
+			"product_statistics_results": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Results when product_statistics query is used.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"service":           schema.StringAttribute{Computed: true, Description: "Service name."},
+						"vm_id":             schema.Int64Attribute{Computed: true, Description: "VM ID."},
+						"vm_name":           schema.StringAttribute{Computed: true, Description: "VM name."},
+						"head_product_id":   schema.Int64Attribute{Computed: true, Description: "Head product ID."},
+						"head_product_name": schema.StringAttribute{Computed: true, Description: "Head product name."},
+						"currency":          schema.StringAttribute{Computed: true, Description: "Cost currency."},
+						"cost":              schema.Float64Attribute{Computed: true, Description: "Cost value."},
+						"provider_name":     schema.StringAttribute{Computed: true, Description: "Cloud provider name."},
+						"country":           schema.StringAttribute{Computed: true, Description: "Country."},
+						"location":          schema.StringAttribute{Computed: true, Description: "Location."},
+						"latitude":          schema.Float64Attribute{Computed: true, Description: "Geographic latitude."},
+						"longitude":         schema.Float64Attribute{Computed: true, Description: "Geographic longitude."},
+						"status_normalized": schema.StringAttribute{Computed: true, Description: "Normalized status."},
+						"cpu_total":         schema.Float64Attribute{Computed: true, Description: "Total CPU."},
+						"ram_total":         schema.Float64Attribute{Computed: true, Description: "Total RAM."},
+						"disk_usage_total":  schema.Float64Attribute{Computed: true, Description: "Total disk usage."},
+						"cpu_usage":         schema.Float64Attribute{Computed: true, Description: "CPU usage."},
+						"ram_usage":         schema.Float64Attribute{Computed: true, Description: "RAM usage."},
+						"disk_usage":        schema.Float64Attribute{Computed: true, Description: "Disk usage."},
+						"empty_value":       schema.Int64Attribute{Computed: true, Description: "Empty value placeholder."},
+					},
+				},
+			},
+			"project_summary_results": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Results when project_summary query is used.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"service":           schema.StringAttribute{Computed: true, Description: "Service name."},
+						"all_installations": schema.Int64Attribute{Computed: true, Description: "Total number of installations."},
+						"cost":              schema.Float64Attribute{Computed: true, Description: "Total cost."},
+					},
+				},
+			},
+			"resource_analysis_results": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Results when resource_analysis query is used.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"service":             schema.StringAttribute{Computed: true, Description: "Service name."},
+						"timecode":            schema.StringAttribute{Computed: true, Description: "Time code."},
+						"cpu_cores_number":    schema.Float64Attribute{Computed: true, Description: "Number of CPU cores."},
+						"ram_total_amount_gb": schema.Float64Attribute{Computed: true, Description: "Total RAM in GB."},
+						"disk_space_total_gb": schema.Float64Attribute{Computed: true, Description: "Total disk space in GB."},
+						"type":                schema.StringAttribute{Computed: true, Description: "Resource type."},
+					},
+				},
+			},
+			"vm_analytics_results": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Results when vm_analytics query is used.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"vm_id":                            schema.Int64Attribute{Computed: true, Description: "VM ID."},
+						"timecode":                         schema.StringAttribute{Computed: true, Description: "Time code."},
+						"avg_date_start":                   schema.StringAttribute{Computed: true, Description: "Average period start date."},
+						"avg_date_end":                     schema.StringAttribute{Computed: true, Description: "Average period end date."},
+						"quantiles_date_start":             schema.StringAttribute{Computed: true, Description: "Quantiles period start date."},
+						"quantiles_date_end":               schema.StringAttribute{Computed: true, Description: "Quantiles period end date."},
+						"cpu_data_present":                 schema.Int64Attribute{Computed: true, Description: "CPU data present flag."},
+						"cpu_utilization_average_cores":    schema.Float64Attribute{Computed: true, Description: "Average CPU utilization in cores."},
+						"cpu_cores_number":                 schema.Int64Attribute{Computed: true, Description: "Total CPU cores."},
+						"cpu_total_percent":                schema.Int64Attribute{Computed: true, Description: "CPU total percent."},
+						"cpu_human_label":                  schema.StringAttribute{Computed: true, Description: "Human-readable CPU label."},
+						"ram_data_present":                 schema.Int64Attribute{Computed: true, Description: "RAM data present flag."},
+						"ram_usage_average_mb":             schema.Float64Attribute{Computed: true, Description: "Average RAM usage in MB."},
+						"ram_total_amount_mb":              schema.Int64Attribute{Computed: true, Description: "Total RAM in MB."},
+						"ram_human_label":                  schema.StringAttribute{Computed: true, Description: "Human-readable RAM label."},
+						"disk_used_data_present":           schema.Int64Attribute{Computed: true, Description: "Disk used data present flag."},
+						"disk_space_used_gb":               schema.Float64Attribute{Computed: true, Description: "Disk space used in GB."},
+						"disk_space_total_gb":              schema.Float64Attribute{Computed: true, Description: "Total disk space in GB."},
+						"disk_space_human_label":           schema.StringAttribute{Computed: true, Description: "Human-readable disk label."},
+						"disk_write_data_present":          schema.Int64Attribute{Computed: true, Description: "Disk write data present flag."},
+						"disk_write_bps":                   schema.Float64Attribute{Computed: true, Description: "Disk write speed in bytes/s."},
+						"disk_write_human":                 schema.Float64Attribute{Computed: true, Description: "Disk write human value."},
+						"disk_write_human_label":           schema.StringAttribute{Computed: true, Description: "Human-readable disk write label."},
+						"disk_read_data_present":           schema.Int64Attribute{Computed: true, Description: "Disk read data present flag."},
+						"disk_read_bps":                    schema.Float64Attribute{Computed: true, Description: "Disk read speed in bytes/s."},
+						"disk_read_human":                  schema.Float64Attribute{Computed: true, Description: "Disk read human value."},
+						"disk_read_human_label":            schema.StringAttribute{Computed: true, Description: "Human-readable disk read label."},
+						"network_out_data_present":         schema.Int64Attribute{Computed: true, Description: "Network out data present flag."},
+						"network_out_bps":                  schema.Float64Attribute{Computed: true, Description: "Network out speed in bytes/s."},
+						"network_out_human":                schema.Float64Attribute{Computed: true, Description: "Network out human value."},
+						"network_out_human_label":          schema.StringAttribute{Computed: true, Description: "Human-readable network out label."},
+						"network_in_data_present":          schema.Int64Attribute{Computed: true, Description: "Network in data present flag."},
+						"network_in_bps":                   schema.Float64Attribute{Computed: true, Description: "Network in speed in bytes/s."},
+						"network_in_human":                 schema.Float64Attribute{Computed: true, Description: "Network in human value."},
+						"network_in_human_label":           schema.StringAttribute{Computed: true, Description: "Human-readable network in label."},
+						"gpu_data_present":                 schema.Int64Attribute{Computed: true, Description: "GPU data present flag."},
+						"gpu_utilization_avg_percent":      schema.Float64Attribute{Computed: true, Description: "Average GPU utilization percent."},
+						"gpu_total_percent":                schema.Int64Attribute{Computed: true, Description: "GPU total percent."},
+						"gpu_human_label":                  schema.StringAttribute{Computed: true, Description: "Human-readable GPU label."},
+						"gpu_ram_data_present":             schema.Int64Attribute{Computed: true, Description: "GPU RAM data present flag."},
+						"gpu_ram_usage_avg_gb":             schema.Float64Attribute{Computed: true, Description: "Average GPU RAM usage in GB."},
+						"gpu_ram_total_gb":                 schema.Float64Attribute{Computed: true, Description: "Total GPU RAM in GB."},
+						"gpu_ram_human_label":              schema.StringAttribute{Computed: true, Description: "Human-readable GPU RAM label."},
+						"gpu_ram_utilization_data_present": schema.Int64Attribute{Computed: true, Description: "GPU RAM utilization data present flag."},
+						"gpu_ram_utilization_avg_percent":  schema.Float64Attribute{Computed: true, Description: "Average GPU RAM utilization percent."},
+						"gpu_ram_utilization_total_percent": schema.Int64Attribute{Computed: true, Description: "GPU RAM utilization total percent."},
+						"gpu_ram_utilization_human_label":  schema.StringAttribute{Computed: true, Description: "Human-readable GPU RAM utilization label."},
+						"is_shown_short":                   schema.Int64Attribute{Computed: true, Description: "Is shown short flag."},
+						"type":                             schema.StringAttribute{Computed: true, Description: "Record type."},
+					},
+				},
+			},
+			"vm_monitoring_results": schema.ListNestedAttribute{
+				Computed:    true,
+				Description: "Results when vm_monitoring query is used.",
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"timecode":                          schema.StringAttribute{Computed: true, Description: "Time code."},
+						"cpu_data_present":                  schema.Int64Attribute{Computed: true, Description: "CPU data present flag."},
+						"cpu_utilization_average_cores":     schema.Float64Attribute{Computed: true, Description: "Average CPU utilization in cores."},
+						"avg_cpu_utilization_average_cores": schema.Float64Attribute{Computed: true, Description: "Period average CPU utilization in cores."},
+						"max_cpu_utilization_average_cores": schema.Float64Attribute{Computed: true, Description: "Period max CPU utilization in cores."},
+						"cpu_total_percent":                 schema.Int64Attribute{Computed: true, Description: "CPU total percent."},
+						"cpu_human_label":                   schema.StringAttribute{Computed: true, Description: "Human-readable CPU label."},
+						"ram_data_present":                  schema.Int64Attribute{Computed: true, Description: "RAM data present flag."},
+						"ram_usage_average_gb":              schema.Float64Attribute{Computed: true, Description: "Average RAM usage in GB."},
+						"avg_ram_usage_average_gb":          schema.Float64Attribute{Computed: true, Description: "Period average RAM usage in GB."},
+						"max_ram_usage_average_gb":          schema.Float64Attribute{Computed: true, Description: "Period max RAM usage in GB."},
+						"ram_total_amount_gb":               schema.Float64Attribute{Computed: true, Description: "Total RAM in GB."},
+						"ram_human_label":                   schema.StringAttribute{Computed: true, Description: "Human-readable RAM label."},
+						"disk_used_data_present":            schema.Int64Attribute{Computed: true, Description: "Disk used data present flag."},
+						"disk_space_used_gb":                schema.Float64Attribute{Computed: true, Description: "Disk space used in GB."},
+						"avg_disk_space_used_gb":            schema.Float64Attribute{Computed: true, Description: "Period average disk space used in GB."},
+						"max_disk_space_used_gb":            schema.Float64Attribute{Computed: true, Description: "Period max disk space used in GB."},
+						"disk_space_total_gb":               schema.Int64Attribute{Computed: true, Description: "Total disk space in GB."},
+						"disk_space_human_label":            schema.StringAttribute{Computed: true, Description: "Human-readable disk label."},
+						"disk_write_data_present":           schema.Int64Attribute{Computed: true, Description: "Disk write data present flag."},
+						"disk_write_coef":                   schema.Float64Attribute{Computed: true, Description: "Disk write coefficient."},
+						"disk_write_human":                  schema.Float64Attribute{Computed: true, Description: "Disk write human value."},
+						"avg_disk_write_human":              schema.Float64Attribute{Computed: true, Description: "Period average disk write human value."},
+						"max_disk_write_human":              schema.Float64Attribute{Computed: true, Description: "Period max disk write human value."},
+						"disk_write_human_label":            schema.StringAttribute{Computed: true, Description: "Human-readable disk write label."},
+						"disk_read_data_present":            schema.Int64Attribute{Computed: true, Description: "Disk read data present flag."},
+						"disk_read_coef":                    schema.Float64Attribute{Computed: true, Description: "Disk read coefficient."},
+						"disk_read_human":                   schema.Float64Attribute{Computed: true, Description: "Disk read human value."},
+						"avg_disk_read_human":               schema.Float64Attribute{Computed: true, Description: "Period average disk read human value."},
+						"max_disk_read_human":               schema.Float64Attribute{Computed: true, Description: "Period max disk read human value."},
+						"disk_read_human_label":             schema.StringAttribute{Computed: true, Description: "Human-readable disk read label."},
+						"network_out_data_present":          schema.Int64Attribute{Computed: true, Description: "Network out data present flag."},
+						"network_out_coef":                  schema.Float64Attribute{Computed: true, Description: "Network out coefficient."},
+						"network_out_human":                 schema.Float64Attribute{Computed: true, Description: "Network out human value."},
+						"avg_network_out_human":             schema.Float64Attribute{Computed: true, Description: "Period average network out human value."},
+						"max_network_out_human":             schema.Float64Attribute{Computed: true, Description: "Period max network out human value."},
+						"network_out_human_label":           schema.StringAttribute{Computed: true, Description: "Human-readable network out label."},
+						"network_in_data_present":           schema.Int64Attribute{Computed: true, Description: "Network in data present flag."},
+						"network_in_coef":                   schema.Float64Attribute{Computed: true, Description: "Network in coefficient."},
+						"network_in_human":                  schema.Float64Attribute{Computed: true, Description: "Network in human value."},
+						"avg_network_in_human":              schema.Float64Attribute{Computed: true, Description: "Period average network in human value."},
+						"max_network_in_human":              schema.Float64Attribute{Computed: true, Description: "Period max network in human value."},
+						"network_in_human_label":            schema.StringAttribute{Computed: true, Description: "Human-readable network in label."},
+						"gpu_ram_usage_data_present":        schema.Int64Attribute{Computed: true, Description: "GPU RAM usage data present flag."},
+						"gpu_ram_usage_avg_gb":              schema.Float64Attribute{Computed: true, Description: "Average GPU RAM usage in GB."},
+						"avg_gpu_ram_usage_avg_gb":          schema.Float64Attribute{Computed: true, Description: "Period average GPU RAM usage in GB."},
+						"max_gpu_ram_usage_avg_gb":          schema.Float64Attribute{Computed: true, Description: "Period max GPU RAM usage in GB."},
+						"gpu_ram_usage_human_label":         schema.StringAttribute{Computed: true, Description: "Human-readable GPU RAM usage label."},
+						"gpu_ram_utilization_avg_present":   schema.Int64Attribute{Computed: true, Description: "GPU RAM utilization avg present flag."},
+						"gpu_ram_utilization_avg_percent":   schema.Float64Attribute{Computed: true, Description: "Average GPU RAM utilization percent."},
+						"avg_gpu_ram_utilization_avg_percent": schema.Float64Attribute{Computed: true, Description: "Period average GPU RAM utilization percent."},
+						"max_gpu_ram_utilization_avg_percent": schema.Float64Attribute{Computed: true, Description: "Period max GPU RAM utilization percent."},
+						"gpu_ram_utilization_human_label":   schema.StringAttribute{Computed: true, Description: "Human-readable GPU RAM utilization label."},
+						"gpu_utilization_data_present":      schema.Int64Attribute{Computed: true, Description: "GPU utilization data present flag."},
+						"gpu_utilization_avg_percent":       schema.Float64Attribute{Computed: true, Description: "Average GPU utilization percent."},
+						"avg_gpu_utilization_avg_percent":   schema.Float64Attribute{Computed: true, Description: "Period average GPU utilization percent."},
+						"max_gpu_utilization_avg_percent":   schema.Float64Attribute{Computed: true, Description: "Period max GPU utilization percent."},
+						"gpu_utilization_human_label":       schema.StringAttribute{Computed: true, Description: "Human-readable GPU utilization label."},
+					},
+				},
+			},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Configure
+// ---------------------------------------------------------------------------
+
+func (d *statisticalDataDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+func (d *statisticalDataDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data statisticalDataDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate exactly one query variant is set
+	queryCount := 0
+	if data.KubernetesClusterChangingMetrics != nil {
+		queryCount++
+	}
+	if data.KubernetesClusterCurrentState != nil {
+		queryCount++
+	}
+	if data.KubernetesClusterMetrics != nil {
+		queryCount++
+	}
+	if data.KubernetesClusterObjectStates != nil {
+		queryCount++
+	}
+	if data.KubernetesClusterObjects != nil {
+		queryCount++
+	}
+	if data.ProductStatistics != nil {
+		queryCount++
+	}
+	if data.ProjectSummary != nil {
+		queryCount++
+	}
+	if data.ResourceAnalysis != nil {
+		queryCount++
+	}
+	if data.VmAnalytics != nil {
+		queryCount++
+	}
+	if data.VmMonitoring != nil {
+		queryCount++
+	}
+	if queryCount != 1 {
+		resp.Diagnostics.AddError("Configuration Error",
+			fmt.Sprintf("Exactly one query block must be set, got %d.", queryCount))
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+
+	// Build the SDK request body based on which query block is set.
+	var body emmaSdk.GetStatisticalDataRequest
+
+	switch {
+	case data.KubernetesClusterChangingMetrics != nil:
+		q := data.KubernetesClusterChangingMetrics
+		f := q.Filters
+		changingMetrics := make([]string, 0)
+		f.ChangingMetrics.ElementsAs(ctx, &changingMetrics, false)
+		subobjects := make([]string, 0)
+		f.CustomFilterSubobjects.ElementsAs(ctx, &subobjects, false)
+		cpuRule := emmaSdk.NullableString{}
+		if !f.CustomFilterAvgCpuRule.IsNull() {
+			v := f.CustomFilterAvgCpuRule.ValueString()
+			cpuRule.Set(&v)
+		}
+		filters := emmaSdk.KubernetesClusterChangingMetricsQueryFilters{
+			ObjectType:                  f.ObjectType.ValueString(),
+			ObjectName:                  f.ObjectName.ValueString(),
+			BreakdownLevel:              f.BreakdownLevel.ValueString(),
+			ChangingMetrics:             changingMetrics,
+			Timespan:                    f.Timespan.ValueString(),
+			CustomFilterState:           f.CustomFilterState.ValueString(),
+			CustomFilterAvgCpuRule:      cpuRule,
+			CustomFilterAvgCpuValue:     float32(f.CustomFilterAvgCpuValue.ValueFloat64()),
+			CustomFilterAvgMemoryRule:   f.CustomFilterAvgMemoryRule.ValueString(),
+			CustomFilterAvgMemoryValue:  float32(f.CustomFilterAvgMemoryValue.ValueFloat64()),
+			CustomFilterAvgStorageRule:  f.CustomFilterAvgStorageRule.ValueString(),
+			CustomFilterAvgStorageValue: float32(f.CustomFilterAvgStorageValue.ValueFloat64()),
+			CustomFilterSubobjects:      subobjects,
+		}
+		body = emmaSdk.KubernetesClusterChangingMetricsQueryAsGetStatisticalDataRequest(
+			emmaSdk.NewKubernetesClusterChangingMetricsQuery(
+				q.DatasetName.ValueString(),
+				int32(q.CoreClusterId.ValueInt64()),
+				filters,
+			),
+		)
+
+	case data.KubernetesClusterCurrentState != nil:
+		q := data.KubernetesClusterCurrentState
+		f := q.Filters
+		currentStateMetrics := make([]string, 0)
+		f.CurrentStateMetrics.ElementsAs(ctx, &currentStateMetrics, false)
+		subobjects := make([]string, 0)
+		f.CustomFilterSubobjects.ElementsAs(ctx, &subobjects, false)
+		cpuRule := emmaSdk.NullableString{}
+		if !f.CustomFilterAvgCpuRule.IsNull() {
+			v := f.CustomFilterAvgCpuRule.ValueString()
+			cpuRule.Set(&v)
+		}
+		filters := emmaSdk.KubernetesClusterCurrentStateQueryFilters{
+			ObjectType:                  f.ObjectType.ValueString(),
+			ObjectName:                  f.ObjectName.ValueString(),
+			BreakdownLevel:              f.BreakdownLevel.ValueString(),
+			CurrentStateMetrics:         currentStateMetrics,
+			CustomFilterState:           f.CustomFilterState.ValueString(),
+			CustomFilterAvgCpuRule:      cpuRule,
+			CustomFilterAvgCpuValue:     float32(f.CustomFilterAvgCpuValue.ValueFloat64()),
+			CustomFilterAvgMemoryRule:   f.CustomFilterAvgMemoryRule.ValueString(),
+			CustomFilterAvgMemoryValue:  float32(f.CustomFilterAvgMemoryValue.ValueFloat64()),
+			CustomFilterAvgStorageRule:  f.CustomFilterAvgStorageRule.ValueString(),
+			CustomFilterAvgStorageValue: float32(f.CustomFilterAvgStorageValue.ValueFloat64()),
+			CustomFilterSubobjects:      subobjects,
+		}
+		body = emmaSdk.KubernetesClusterCurrentStateQueryAsGetStatisticalDataRequest(
+			emmaSdk.NewKubernetesClusterCurrentStateQuery(
+				q.DatasetName.ValueString(),
+				int32(q.CoreClusterId.ValueInt64()),
+				filters,
+			),
+		)
+
+	case data.KubernetesClusterMetrics != nil:
+		q := data.KubernetesClusterMetrics
+		f := q.Filters
+		filters := emmaSdk.KubernetesClusterMetricsQueryFilters{
+			ObjectType:     f.ObjectType.ValueString(),
+			ObjectName:     f.ObjectName.ValueString(),
+			BreakdownLevel: f.BreakdownLevel.ValueString(),
+		}
+		body = emmaSdk.KubernetesClusterMetricsQueryAsGetStatisticalDataRequest(
+			emmaSdk.NewKubernetesClusterMetricsQuery(
+				q.DatasetName.ValueString(),
+				int32(q.CoreClusterId.ValueInt64()),
+				filters,
+			),
+		)
+
+	case data.KubernetesClusterObjectStates != nil:
+		q := data.KubernetesClusterObjectStates
+		f := q.Filters
+		objectStatesMetrics := make([]string, 0)
+		f.ObjectStatesMetrics.ElementsAs(ctx, &objectStatesMetrics, false)
+		filters := emmaSdk.KubernetesClusterObjectStatesQueryFilters{
+			ObjectType:          f.ObjectType.ValueString(),
+			ObjectName:          f.ObjectName.ValueString(),
+			BreakdownLevel:      f.BreakdownLevel.ValueString(),
+			ObjectStatesMetrics: objectStatesMetrics,
+		}
+		body = emmaSdk.KubernetesClusterObjectStatesQueryAsGetStatisticalDataRequest(
+			emmaSdk.NewKubernetesClusterObjectStatesQuery(
+				q.DatasetName.ValueString(),
+				int32(q.CoreClusterId.ValueInt64()),
+				filters,
+			),
+		)
+
+	case data.KubernetesClusterObjects != nil:
+		q := data.KubernetesClusterObjects
+		body = emmaSdk.KubernetesClusterObjectsQueryAsGetStatisticalDataRequest(
+			emmaSdk.NewKubernetesClusterObjectsQuery(
+				q.DatasetName.ValueString(),
+				int32(q.CoreClusterId.ValueInt64()),
+			),
+		)
+
+	case data.ProductStatistics != nil:
+		q := data.ProductStatistics
+		filters := emmaSdk.ProductStatisticsQueryFilters{
+			ServiceFilter: q.Filters.ServiceFilter.ValueString(),
+		}
+		body = emmaSdk.ProductStatisticsQueryAsGetStatisticalDataRequest(
+			emmaSdk.NewProductStatisticsQuery(q.DatasetName.ValueString(), filters),
+		)
+
+	case data.ProjectSummary != nil:
+		q := data.ProjectSummary
+		body = emmaSdk.ProjectSummaryQueryAsGetStatisticalDataRequest(
+			emmaSdk.NewProjectSummaryQuery(q.DatasetName.ValueString()),
+		)
+
+	case data.ResourceAnalysis != nil:
+		q := data.ResourceAnalysis
+		filters := emmaSdk.ResourceAnalysisQueryFilters{
+			PeriodStart: q.Filters.PeriodStart.ValueString(),
+			PeriodEnd:   q.Filters.PeriodEnd.ValueString(),
+		}
+		body = emmaSdk.ResourceAnalysisQueryAsGetStatisticalDataRequest(
+			emmaSdk.NewResourceAnalysisQuery(q.DatasetName.ValueString(), filters),
+		)
+
+	case data.VmAnalytics != nil:
+		q := data.VmAnalytics
+		body = emmaSdk.VmAnalyticsQueryAsGetStatisticalDataRequest(
+			emmaSdk.NewVmAnalyticsQuery(q.DatasetName.ValueString(), int32(q.VmId.ValueInt64())),
+		)
+
+	case data.VmMonitoring != nil:
+		q := data.VmMonitoring
+		filters := emmaSdk.VmMonitoringQueryFilters{
+			Period: q.Filters.Period.ValueString(),
+		}
+		body = emmaSdk.VmMonitoringQueryAsGetStatisticalDataRequest(
+			emmaSdk.NewVmMonitoringQuery(q.DatasetName.ValueString(), int32(q.VmId.ValueInt64()), filters),
+		)
+	}
+
+	result, response, err := d.apiClient.StatisticsAPI.GetStatisticalData(auth).GetStatisticalDataRequest(body).Execute() //nolint:staticcheck
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to retrieve statistical data, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	// Initialize all result lists to empty; populate only the matching one.
+	var diags diag.Diagnostics
+
+	emptyChangingMetrics, d1 := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: k8sChangingMetricsResultModel{}.attrTypes()}, []k8sChangingMetricsResultModel{})
+	diags.Append(d1...)
+	emptyCurrentState, d2 := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: k8sCurrentStateResultModel{}.attrTypes()}, []k8sCurrentStateResultModel{})
+	diags.Append(d2...)
+	emptyMetrics, d3 := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: k8sMetricsResultModel{}.attrTypes()}, []k8sMetricsResultModel{})
+	diags.Append(d3...)
+	emptyObjectStates, d4 := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: k8sObjectStatesResultModel{}.attrTypes()}, []k8sObjectStatesResultModel{})
+	diags.Append(d4...)
+	emptyObjects, d5 := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: k8sObjectsResultModel{}.attrTypes()}, []k8sObjectsResultModel{})
+	diags.Append(d5...)
+	emptyProductStats, d6 := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: productStatisticsResultModel{}.attrTypes()}, []productStatisticsResultModel{})
+	diags.Append(d6...)
+	emptyProjectSummary, d7 := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: projectSummaryResultModel{}.attrTypes()}, []projectSummaryResultModel{})
+	diags.Append(d7...)
+	emptyResourceAnalysis, d8 := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: resourceAnalysisResultModel{}.attrTypes()}, []resourceAnalysisResultModel{})
+	diags.Append(d8...)
+	emptyVmAnalytics, d9 := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: vmAnalyticsResultModel{}.attrTypes()}, []vmAnalyticsResultModel{})
+	diags.Append(d9...)
+	emptyVmMonitoring, d10 := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: vmMonitoringResultModel{}.attrTypes()}, []vmMonitoringResultModel{})
+	diags.Append(d10...)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	data.KubernetesClusterChangingMetricsResults = emptyChangingMetrics
+	data.KubernetesClusterCurrentStateResults = emptyCurrentState
+	data.KubernetesClusterMetricsResults = emptyMetrics
+	data.KubernetesClusterObjectStatesResults = emptyObjectStates
+	data.KubernetesClusterObjectsResults = emptyObjects
+	data.ProductStatisticsResults = emptyProductStats
+	data.ProjectSummaryResults = emptyProjectSummary
+	data.ResourceAnalysisResults = emptyResourceAnalysis
+	data.VmAnalyticsResults = emptyVmAnalytics
+	data.VmMonitoringResults = emptyVmMonitoring
+
+	// Map the populated response variant.
+	switch {
+	case result.ArrayOfKubernetesClusterChangingMetricsResponse != nil:
+		list, listDiags := convertK8sChangingMetricsResults(ctx, *result.ArrayOfKubernetesClusterChangingMetricsResponse)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.KubernetesClusterChangingMetricsResults = list
+
+	case result.ArrayOfKubernetesClusterCurrentStateResponse != nil:
+		list, listDiags := convertK8sCurrentStateResults(ctx, *result.ArrayOfKubernetesClusterCurrentStateResponse)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.KubernetesClusterCurrentStateResults = list
+
+	case result.ArrayOfKubernetesClusterMetricsResponse != nil:
+		list, listDiags := convertK8sMetricsResults(ctx, *result.ArrayOfKubernetesClusterMetricsResponse)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.KubernetesClusterMetricsResults = list
+
+	case result.ArrayOfKubernetesClusterObjectStatesResponse != nil:
+		list, listDiags := convertK8sObjectStatesResults(ctx, *result.ArrayOfKubernetesClusterObjectStatesResponse)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.KubernetesClusterObjectStatesResults = list
+
+	case result.ArrayOfKubernetesClusterObjectsResponse != nil:
+		list, listDiags := convertK8sObjectsResults(ctx, *result.ArrayOfKubernetesClusterObjectsResponse)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.KubernetesClusterObjectsResults = list
+
+	case result.ArrayOfProductStatisticsResponse != nil:
+		list, listDiags := convertProductStatisticsResults(ctx, *result.ArrayOfProductStatisticsResponse)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.ProductStatisticsResults = list
+
+	case result.ArrayOfProjectSummaryResponse != nil:
+		list, listDiags := convertProjectSummaryResults(ctx, *result.ArrayOfProjectSummaryResponse)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.ProjectSummaryResults = list
+
+	case result.ArrayOfResourceAnalysisResponse != nil:
+		list, listDiags := convertResourceAnalysisResults(ctx, *result.ArrayOfResourceAnalysisResponse)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.ResourceAnalysisResults = list
+
+	case result.ArrayOfVmAnalyticsResponse != nil:
+		list, listDiags := convertVmAnalyticsResults(ctx, *result.ArrayOfVmAnalyticsResponse)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.VmAnalyticsResults = list
+
+	case result.ArrayOfVmMonitoringResponse != nil:
+		list, listDiags := convertVmMonitoringResults(ctx, *result.ArrayOfVmMonitoringResponse)
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.VmMonitoringResults = list
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+func convertK8sChangingMetricsResults(ctx context.Context, items []emmaSdk.KubernetesClusterChangingMetricsResponse) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	models := make([]k8sChangingMetricsResultModel, 0, len(items))
+	for _, item := range items {
+		m := k8sChangingMetricsResultModel{}
+		if item.SubobjectName != nil {
+			m.SubobjectName = types.StringValue(*item.SubobjectName)
+		} else {
+			m.SubobjectName = types.StringNull()
+		}
+		if item.MetricName != nil {
+			m.MetricName = types.StringValue(*item.MetricName)
+		} else {
+			m.MetricName = types.StringNull()
+		}
+		if item.UiMetricGroup != nil {
+			m.UiMetricGroup = types.StringValue(*item.UiMetricGroup)
+		} else {
+			m.UiMetricGroup = types.StringNull()
+		}
+		if item.UiColorGroupId != nil {
+			m.UiColorGroupId = types.Int64Value(int64(*item.UiColorGroupId))
+		} else {
+			m.UiColorGroupId = types.Int64Null()
+		}
+		if item.UiMetricName != nil {
+			m.UiMetricName = types.StringValue(*item.UiMetricName)
+		} else {
+			m.UiMetricName = types.StringNull()
+		}
+		if item.HumanLabel != nil {
+			m.HumanLabel = types.StringValue(*item.HumanLabel)
+		} else {
+			m.HumanLabel = types.StringNull()
+		}
+		timecodesList, ld := types.ListValueFrom(ctx, types.StringType, item.Timecodes)
+		diags.Append(ld...)
+		m.Timecodes = timecodesList
+
+		// linechart values are []float32 — convert to []float64 for Terraform
+		float64Vals := make([]float64, len(item.LinechartValues))
+		for i, v := range item.LinechartValues {
+			float64Vals[i] = float64(v)
+		}
+		linechartList, ld2 := types.ListValueFrom(ctx, types.Float64Type, float64Vals)
+		diags.Append(ld2...)
+		m.LinechartValues = linechartList
+
+		if item.TreemapValues != nil {
+			m.TreemapValues = types.Float64Value(float64(*item.TreemapValues))
+		} else {
+			m.TreemapValues = types.Float64Null()
+		}
+		models = append(models, m)
+	}
+	list, ld := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: k8sChangingMetricsResultModel{}.attrTypes()}, models)
+	diags.Append(ld...)
+	return list, diags
+}
+
+func convertK8sCurrentStateResults(ctx context.Context, items []emmaSdk.KubernetesClusterCurrentStateResponse) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	models := make([]k8sCurrentStateResultModel, 0, len(items))
+	for _, item := range items {
+		m := k8sCurrentStateResultModel{}
+		if item.SubobjectName != nil {
+			m.SubobjectName = types.StringValue(*item.SubobjectName)
+		} else {
+			m.SubobjectName = types.StringNull()
+		}
+		if item.MetricName != nil {
+			m.MetricName = types.StringValue(*item.MetricName)
+		} else {
+			m.MetricName = types.StringNull()
+		}
+		if item.UiMetricGroup != nil {
+			m.UiMetricGroup = types.StringValue(*item.UiMetricGroup)
+		} else {
+			m.UiMetricGroup = types.StringNull()
+		}
+		if item.UiColorGroupId != nil {
+			m.UiColorGroupId = types.Int64Value(int64(*item.UiColorGroupId))
+		} else {
+			m.UiColorGroupId = types.Int64Null()
+		}
+		if item.UiMetricName != nil {
+			m.UiMetricName = types.StringValue(*item.UiMetricName)
+		} else {
+			m.UiMetricName = types.StringNull()
+		}
+		if item.Value != nil {
+			m.Value = types.Float64Value(float64(*item.Value))
+		} else {
+			m.Value = types.Float64Null()
+		}
+		models = append(models, m)
+	}
+	list, ld := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: k8sCurrentStateResultModel{}.attrTypes()}, models)
+	diags.Append(ld...)
+	return list, diags
+}
+
+func convertK8sMetricsResults(ctx context.Context, items []emmaSdk.KubernetesClusterMetricsResponse) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	models := make([]k8sMetricsResultModel, 0, len(items))
+	for _, item := range items {
+		m := k8sMetricsResultModel{}
+		if item.MetricName != nil {
+			m.MetricName = types.StringValue(*item.MetricName)
+		} else {
+			m.MetricName = types.StringNull()
+		}
+		if item.UiMetricGroup != nil {
+			m.UiMetricGroup = types.StringValue(*item.UiMetricGroup)
+		} else {
+			m.UiMetricGroup = types.StringNull()
+		}
+		if item.UiMetricName != nil {
+			m.UiMetricName = types.StringValue(*item.UiMetricName)
+		} else {
+			m.UiMetricName = types.StringNull()
+		}
+		if item.BlockName != nil {
+			m.BlockName = types.StringValue(*item.BlockName)
+		} else {
+			m.BlockName = types.StringNull()
+		}
+		models = append(models, m)
+	}
+	list, ld := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: k8sMetricsResultModel{}.attrTypes()}, models)
+	diags.Append(ld...)
+	return list, diags
+}
+
+func convertK8sObjectStatesResults(ctx context.Context, items []emmaSdk.KubernetesClusterObjectStatesResponse) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	models := make([]k8sObjectStatesResultModel, 0, len(items))
+	for _, item := range items {
+		m := k8sObjectStatesResultModel{}
+		if item.MetricName != nil {
+			m.MetricName = types.StringValue(*item.MetricName)
+		} else {
+			m.MetricName = types.StringNull()
+		}
+		if item.UiMetricGroup != nil {
+			m.UiMetricGroup = types.StringValue(*item.UiMetricGroup)
+		} else {
+			m.UiMetricGroup = types.StringNull()
+		}
+		// UiColorGroupId is []int32 — convert to []int64
+		int64ColorIds := make([]int64, len(item.UiColorGroupId))
+		for i, v := range item.UiColorGroupId {
+			int64ColorIds[i] = int64(v)
+		}
+		colorList, ld := types.ListValueFrom(ctx, types.Int64Type, int64ColorIds)
+		diags.Append(ld...)
+		m.UiColorGroupId = colorList
+
+		if item.UiMetricName != nil {
+			m.UiMetricName = types.StringValue(*item.UiMetricName)
+		} else {
+			m.UiMetricName = types.StringNull()
+		}
+		if item.SubobjectName != nil {
+			m.SubobjectName = types.StringValue(*item.SubobjectName)
+		} else {
+			m.SubobjectName = types.StringNull()
+		}
+		valueList, ld2 := types.ListValueFrom(ctx, types.StringType, item.Value)
+		diags.Append(ld2...)
+		m.Value = valueList
+
+		models = append(models, m)
+	}
+	list, ld := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: k8sObjectStatesResultModel{}.attrTypes()}, models)
+	diags.Append(ld...)
+	return list, diags
+}
+
+func convertK8sObjectsResults(ctx context.Context, items []emmaSdk.KubernetesClusterObjectsResponse) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	models := make([]k8sObjectsResultModel, 0, len(items))
+	for _, item := range items {
+		m := k8sObjectsResultModel{}
+		if item.ObjectType != nil {
+			m.ObjectType = types.StringValue(*item.ObjectType)
+		} else {
+			m.ObjectType = types.StringNull()
+		}
+		if item.ObjectName != nil {
+			m.ObjectName = types.StringValue(*item.ObjectName)
+		} else {
+			m.ObjectName = types.StringNull()
+		}
+		models = append(models, m)
+	}
+	list, ld := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: k8sObjectsResultModel{}.attrTypes()}, models)
+	diags.Append(ld...)
+	return list, diags
+}
+
+func convertProductStatisticsResults(ctx context.Context, items []emmaSdk.ProductStatisticsResponse) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	models := make([]productStatisticsResultModel, 0, len(items))
+	for _, item := range items {
+		m := productStatisticsResultModel{}
+		ptrString := func(p *string) types.String {
+			if p != nil {
+				return types.StringValue(*p)
+			}
+			return types.StringNull()
+		}
+		ptrInt32 := func(p *int32) types.Int64 {
+			if p != nil {
+				return types.Int64Value(int64(*p))
+			}
+			return types.Int64Null()
+		}
+		ptrFloat32 := func(p *float32) types.Float64 {
+			if p != nil {
+				return types.Float64Value(float64(*p))
+			}
+			return types.Float64Null()
+		}
+		m.Service = ptrString(item.Service)
+		m.VmId = ptrInt32(item.VmId)
+		m.VmName = ptrString(item.VmName)
+		m.HeadProductId = ptrInt32(item.HeadProductId)
+		m.HeadProductName = ptrString(item.HeadProductName)
+		m.Currency = ptrString(item.Currency)
+		m.Cost = ptrFloat32(item.Cost)
+		m.ProviderName = ptrString(item.ProviderName)
+		m.Country = ptrString(item.Country)
+		m.Location = ptrString(item.Location)
+		m.Latitude = ptrFloat32(item.Latitude)
+		m.Longitude = ptrFloat32(item.Longitude)
+		m.StatusNormalized = ptrString(item.StatusNormalized)
+		m.CpuTotal = ptrFloat32(item.CpuTotal)
+		m.RamTotal = ptrFloat32(item.RamTotal)
+		m.DiskUsageTotal = ptrFloat32(item.DiskUsageTotal)
+		m.CpuUsage = ptrFloat32(item.CpuUsage)
+		m.RamUsage = ptrFloat32(item.RamUsage)
+		m.DiskUsage = ptrFloat32(item.DiskUsage)
+		m.EmptyValue = ptrInt32(item.EmptyValue)
+		models = append(models, m)
+	}
+	list, ld := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: productStatisticsResultModel{}.attrTypes()}, models)
+	diags.Append(ld...)
+	return list, diags
+}
+
+func convertProjectSummaryResults(ctx context.Context, items []emmaSdk.ProjectSummaryResponse) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	models := make([]projectSummaryResultModel, 0, len(items))
+	for _, item := range items {
+		m := projectSummaryResultModel{}
+		if item.Service != nil {
+			m.Service = types.StringValue(*item.Service)
+		} else {
+			m.Service = types.StringNull()
+		}
+		if item.AllInstallations != nil {
+			m.AllInstallations = types.Int64Value(int64(*item.AllInstallations))
+		} else {
+			m.AllInstallations = types.Int64Null()
+		}
+		if item.Cost != nil {
+			m.Cost = types.Float64Value(float64(*item.Cost))
+		} else {
+			m.Cost = types.Float64Null()
+		}
+		models = append(models, m)
+	}
+	list, ld := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: projectSummaryResultModel{}.attrTypes()}, models)
+	diags.Append(ld...)
+	return list, diags
+}
+
+func convertResourceAnalysisResults(ctx context.Context, items []emmaSdk.ResourceAnalysisResponse) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	models := make([]resourceAnalysisResultModel, 0, len(items))
+	for _, item := range items {
+		m := resourceAnalysisResultModel{}
+		if item.Service != nil {
+			m.Service = types.StringValue(*item.Service)
+		} else {
+			m.Service = types.StringNull()
+		}
+		if item.Timecode != nil {
+			m.Timecode = types.StringValue(*item.Timecode)
+		} else {
+			m.Timecode = types.StringNull()
+		}
+		if item.CpuCoresNumber != nil {
+			m.CpuCoresNumber = types.Float64Value(float64(*item.CpuCoresNumber))
+		} else {
+			m.CpuCoresNumber = types.Float64Null()
+		}
+		if item.RamTotalAmountGb != nil {
+			m.RamTotalAmountGb = types.Float64Value(float64(*item.RamTotalAmountGb))
+		} else {
+			m.RamTotalAmountGb = types.Float64Null()
+		}
+		if item.DiskSpaceTotalGb != nil {
+			m.DiskSpaceTotalGb = types.Float64Value(float64(*item.DiskSpaceTotalGb))
+		} else {
+			m.DiskSpaceTotalGb = types.Float64Null()
+		}
+		if item.Type != nil {
+			m.Type = types.StringValue(*item.Type)
+		} else {
+			m.Type = types.StringNull()
+		}
+		models = append(models, m)
+	}
+	list, ld := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: resourceAnalysisResultModel{}.attrTypes()}, models)
+	diags.Append(ld...)
+	return list, diags
+}
+
+func convertVmAnalyticsResults(ctx context.Context, items []emmaSdk.VmAnalyticsResponse) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	models := make([]vmAnalyticsResultModel, 0, len(items))
+
+	pS := func(p *string) types.String {
+		if p != nil {
+			return types.StringValue(*p)
+		}
+		return types.StringNull()
+	}
+	pI32 := func(p *int32) types.Int64 {
+		if p != nil {
+			return types.Int64Value(int64(*p))
+		}
+		return types.Int64Null()
+	}
+	pF32 := func(p *float32) types.Float64 {
+		if p != nil {
+			return types.Float64Value(float64(*p))
+		}
+		return types.Float64Null()
+	}
+
+	for _, item := range items {
+		m := vmAnalyticsResultModel{
+			VmId:                          pI32(item.VmId),
+			Timecode:                      pS(item.Timecode),
+			AvgDateStart:                  pS(item.AvgDateStart),
+			AvgDateEnd:                    pS(item.AvgDateEnd),
+			QuantilesDateStart:            pS(item.QuantilesDateStart),
+			QuantilesDateEnd:              pS(item.QuantilesDateEnd),
+			CpuDataPresent:                pI32(item.CpuDataPresent),
+			CpuUtilizationAverageCores:    pF32(item.CpuUtilizationAverageCores),
+			CpuCoresNumber:                pI32(item.CpuCoresNumber),
+			CpuTotalPercent:               pI32(item.CpuTotalPercent),
+			CpuHumanLabel:                 pS(item.CpuHumanLabel),
+			RamDataPresent:                pI32(item.RamDataPresent),
+			RamUsageAverageMb:             pF32(item.RamUsageAverageMb),
+			RamTotalAmountMb:              pI32(item.RamTotalAmountMb),
+			RamHumanLabel:                 pS(item.RamHumanLabel),
+			DiskUsedDataPresent:           pI32(item.DiskUsedDataPresent),
+			DiskSpaceUsedGb:               pF32(item.DiskSpaceUsedGb),
+			DiskSpaceTotalGb:              pF32(item.DiskSpaceTotalGb),
+			DiskSpaceHumanLabel:           pS(item.DiskSpaceHumanLabel),
+			DiskWriteDataPresent:          pI32(item.DiskWriteDataPresent),
+			DiskWriteBps:                  pF32(item.DiskWriteBps),
+			DiskWriteHuman:                pF32(item.DiskWriteHuman),
+			DiskWriteHumanLabel:           pS(item.DiskWriteHumanLabel),
+			DiskReadDataPresent:           pI32(item.DiskReadDataPresent),
+			DiskReadBps:                   pF32(item.DiskReadBps),
+			DiskReadHuman:                 pF32(item.DiskReadHuman),
+			DiskReadHumanLabel:            pS(item.DiskReadHumanLabel),
+			NetworkOutDataPresent:         pI32(item.NetworkOutDataPresent),
+			NetworkOutBps:                 pF32(item.NetworkOutBps),
+			NetworkOutHuman:               pF32(item.NetworkOutHuman),
+			NetworkOutHumanLabel:          pS(item.NetworkOutHumanLabel),
+			NetworkInDataPresent:          pI32(item.NetworkInDataPresent),
+			NetworkInBps:                  pF32(item.NetworkInBps),
+			NetworkInHuman:                pF32(item.NetworkInHuman),
+			NetworkInHumanLabel:           pS(item.NetworkInHumanLabel),
+			GpuDataPresent:                pI32(item.GpuDataPresent),
+			GpuUtilizationAvgPercent:      pF32(item.GpuUtilizationAvgPercent),
+			GpuTotalPercent:               pI32(item.GpuTotalPercent),
+			GpuHumanLabel:                 pS(item.GpuHumanLabel),
+			GpuRamDataPresent:             pI32(item.GpuRamDataPresent),
+			GpuRamUsageAvgGb:              pF32(item.GpuRamUsageAvgGb),
+			GpuRamTotalGb:                 pF32(item.GpuRamTotalGb),
+			GpuRamHumanLabel:              pS(item.GpuRamHumanLabel),
+			GpuRamUtilizationDataPresent:  pI32(item.GpuRamUtilizationDataPresent),
+			GpuRamUtilizationAvgPercent:   pF32(item.GpuRamUtilizationAvgPercent),
+			GpuRamUtilizationTotalPercent: pI32(item.GpuRamUtilizationTotalPercent),
+			GpuRamUtilizationHumanLabel:   pS(item.GpuRamUtilizationHumanLabel),
+			IsShownShort:                  pI32(item.IsShownShort),
+			Type:                          pS(item.Type),
+		}
+		models = append(models, m)
+	}
+	list, ld := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: vmAnalyticsResultModel{}.attrTypes()}, models)
+	diags.Append(ld...)
+	return list, diags
+}
+
+func convertVmMonitoringResults(ctx context.Context, items []emmaSdk.VmMonitoringResponse) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	models := make([]vmMonitoringResultModel, 0, len(items))
+
+	pS := func(p *string) types.String {
+		if p != nil {
+			return types.StringValue(*p)
+		}
+		return types.StringNull()
+	}
+	pI32 := func(p *int32) types.Int64 {
+		if p != nil {
+			return types.Int64Value(int64(*p))
+		}
+		return types.Int64Null()
+	}
+	pF32 := func(p *float32) types.Float64 {
+		if p != nil {
+			return types.Float64Value(float64(*p))
+		}
+		return types.Float64Null()
+	}
+
+	for _, item := range items {
+		m := vmMonitoringResultModel{
+			Timecode:                        pS(item.Timecode),
+			CpuDataPresent:                  pI32(item.CpuDataPresent),
+			CpuUtilizationAverageCores:      pF32(item.CpuUtilizationAverageCores),
+			AvgCpuUtilizationAverageCores:   pF32(item.AvgCpuUtilizationAverageCores),
+			MaxCpuUtilizationAverageCores:   pF32(item.MaxCpuUtilizationAverageCores),
+			CpuTotalPercent:                 pI32(item.CpuTotalPercent),
+			CpuHumanLabel:                   pS(item.CpuHumanLabel),
+			RamDataPresent:                  pI32(item.RamDataPresent),
+			RamUsageAverageGb:               pF32(item.RamUsageAverageGb),
+			AvgRamUsageAverageGb:            pF32(item.AvgRamUsageAverageGb),
+			MaxRamUsageAverageGb:            pF32(item.MaxRamUsageAverageGb),
+			RamTotalAmountGb:                pF32(item.RamTotalAmountGb),
+			RamHumanLabel:                   pS(item.RamHumanLabel),
+			DiskUsedDataPresent:             pI32(item.DiskUsedDataPresent),
+			DiskSpaceUsedGb:                 pF32(item.DiskSpaceUsedGb),
+			AvgDiskSpaceUsedGb:              pF32(item.AvgDiskSpaceUsedGb),
+			MaxDiskSpaceUsedGb:              pF32(item.MaxDiskSpaceUsedGb),
+			DiskSpaceTotalGb:                pI32(item.DiskSpaceTotalGb),
+			DiskSpaceHumanLabel:             pS(item.DiskSpaceHumanLabel),
+			DiskWriteDataPresent:            pI32(item.DiskWriteDataPresent),
+			DiskWriteCoef:                   pF32(item.DiskWriteCoef),
+			DiskWriteHuman:                  pF32(item.DiskWriteHuman),
+			AvgDiskWriteHuman:               pF32(item.AvgDiskWriteHuman),
+			MaxDiskWriteHuman:               pF32(item.MaxDiskWriteHuman),
+			DiskWriteHumanLabel:             pS(item.DiskWriteHumanLabel),
+			DiskReadDataPresent:             pI32(item.DiskReadDataPresent),
+			DiskReadCoef:                    pF32(item.DiskReadCoef),
+			DiskReadHuman:                   pF32(item.DiskReadHuman),
+			AvgDiskReadHuman:                pF32(item.AvgDiskReadHuman),
+			MaxDiskReadHuman:                pF32(item.MaxDiskReadHuman),
+			DiskReadHumanLabel:              pS(item.DiskReadHumanLabel),
+			NetworkOutDataPresent:           pI32(item.NetworkOutDataPresent),
+			NetworkOutCoef:                  pF32(item.NetworkOutCoef),
+			NetworkOutHuman:                 pF32(item.NetworkOutHuman),
+			AvgNetworkOutHuman:              pF32(item.AvgNetworkOutHuman),
+			MaxNetworkOutHuman:              pF32(item.MaxNetworkOutHuman),
+			NetworkOutHumanLabel:            pS(item.NetworkOutHumanLabel),
+			NetworkInDataPresent:            pI32(item.NetworkInDataPresent),
+			NetworkInCoef:                   pF32(item.NetworkInCoef),
+			NetworkInHuman:                  pF32(item.NetworkInHuman),
+			AvgNetworkInHuman:               pF32(item.AvgNetworkInHuman),
+			MaxNetworkInHuman:               pF32(item.MaxNetworkInHuman),
+			NetworkInHumanLabel:             pS(item.NetworkInHumanLabel),
+			GpuRamUsageDataPresent:          pI32(item.GpuRamUsageDataPresent),
+			GpuRamUsageAvgGb:                pF32(item.GpuRamUsageAvgGb),
+			AvgGpuRamUsageAvgGb:             pF32(item.AvgGpuRamUsageAvgGb),
+			MaxGpuRamUsageAvgGb:             pF32(item.MaxGpuRamUsageAvgGb),
+			GpuRamUsageHumanLabel:           pS(item.GpuRamUsageHumanLabel),
+			GpuRamUtilizationAvgPresent:     pI32(item.GpuRamUtilizationAvgPresent),
+			GpuRamUtilizationAvgPercent:     pF32(item.GpuRamUtilizationAvgPercent),
+			AvgGpuRamUtilizationAvgPercent:  pF32(item.AvgGpuRamUtilizationAvgPercent),
+			MaxGpuRamUtilizationAvgPercent:  pF32(item.MaxGpuRamUtilizationAvgPercent),
+			GpuRamUtilizationHumanLabel:     pS(item.GpuRamUtilizationHumanLabel),
+			GpuUtilizationDataPresent:       pI32(item.GpuUtilizationDataPresent),
+			GpuUtilizationAvgPercent:        pF32(item.GpuUtilizationAvgPercent),
+			AvgGpuUtilizationAvgPercent:     pF32(item.AvgGpuUtilizationAvgPercent),
+			MaxGpuUtilizationAvgPercent:     pF32(item.MaxGpuUtilizationAvgPercent),
+			GpuUtilizationHumanLabel:        pS(item.GpuUtilizationHumanLabel),
+		}
+		models = append(models, m)
+	}
+	list, ld := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: vmMonitoringResultModel{}.attrTypes()}, models)
+	diags.Append(ld...)
+	return list, diags
+}

--- a/internal/emma/system_volume_configs_data_source.go
+++ b/internal/emma/system_volume_configs_data_source.go
@@ -54,8 +54,8 @@ func (d *systemVolumeConfigsDataSource) Schema(ctx context.Context, req datasour
 			"Use this data source to discover valid system volume sizes and types when planning VM deployments or system volume upsizing.",
 		Attributes: map[string]schema.Attribute{
 			"attached_to_id": schema.Int64Attribute{
-				Description: "ID of the instance the system volume is attached to",
-				Optional:    true,
+				Description: "ID of the instance the system volume is attached to. Required by the server.",
+				Required:    true,
 			},
 			"volume_gb_min": schema.Int64Attribute{
 				Description: "Minimum volume size in gigabytes to filter configurations",
@@ -148,9 +148,7 @@ func (d *systemVolumeConfigsDataSource) Read(ctx context.Context, req datasource
 	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
 	apiReq := d.apiClient.VolumesConfigurationsAPI.GetSystemVolumeConfigs(auth)
 
-	if !data.AttachedToId.IsNull() && !data.AttachedToId.IsUnknown() {
-		apiReq = apiReq.AttachedToId(int32(data.AttachedToId.ValueInt64()))
-	}
+	apiReq = apiReq.AttachedToId(int32(data.AttachedToId.ValueInt64()))
 	if !data.VolumeGbMin.IsNull() && !data.VolumeGbMin.IsUnknown() {
 		apiReq = apiReq.VolumeGbMin(int32(data.VolumeGbMin.ValueInt64()))
 	}

--- a/internal/emma/system_volume_configs_data_source.go
+++ b/internal/emma/system_volume_configs_data_source.go
@@ -1,0 +1,287 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &systemVolumeConfigsDataSource{}
+
+func NewSystemVolumeConfigsDataSource() datasource.DataSource {
+	return &systemVolumeConfigsDataSource{}
+}
+
+type systemVolumeConfigsDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+type systemVolumeConfigsDataSourceModel struct {
+	AttachedToId   types.Int64  `tfsdk:"attached_to_id"`
+	VolumeGbMin    types.Int64  `tfsdk:"volume_gb_min"`
+	VolumeType     types.String `tfsdk:"volume_type"`
+	Configurations types.List   `tfsdk:"configurations"`
+}
+
+type systemVolumeConfigurationModel struct {
+	ProviderId     types.Int64   `tfsdk:"provider_id"`
+	ProviderName   types.String  `tfsdk:"provider_name"`
+	LocationId     types.Int64   `tfsdk:"location_id"`
+	LocationName   types.String  `tfsdk:"location_name"`
+	DataCenterId   types.String  `tfsdk:"data_center_id"`
+	DataCenterName types.String  `tfsdk:"data_center_name"`
+	VolumeGb       types.Int64   `tfsdk:"volume_gb"`
+	VolumeType     types.String  `tfsdk:"volume_type"`
+	PricePerUnit   types.Float64 `tfsdk:"price_per_unit"`
+	PriceCurrency  types.String  `tfsdk:"price_currency"`
+	PriceUnit      types.String  `tfsdk:"price_unit"`
+}
+
+func (d *systemVolumeConfigsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_system_volume_configs"
+}
+
+func (d *systemVolumeConfigsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source retrieves available configurations for system volumes in the Emma platform.\n\n" +
+			"Use this data source to discover valid system volume sizes and types when planning VM deployments or system volume upsizing.",
+		Attributes: map[string]schema.Attribute{
+			"attached_to_id": schema.Int64Attribute{
+				Description: "ID of the instance the system volume is attached to",
+				Optional:    true,
+			},
+			"volume_gb_min": schema.Int64Attribute{
+				Description: "Minimum volume size in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"volume_type": schema.StringAttribute{
+				Description: "Volume type to filter configurations (e.g., ssd, hdd)",
+				Optional:    true,
+			},
+			"configurations": schema.ListNestedAttribute{
+				Description: "List of available system volume configurations",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"provider_id": schema.Int64Attribute{
+							Description: "ID of the cloud provider",
+							Computed:    true,
+						},
+						"provider_name": schema.StringAttribute{
+							Description: "Name of the cloud provider",
+							Computed:    true,
+						},
+						"location_id": schema.Int64Attribute{
+							Description: "Location ID",
+							Computed:    true,
+						},
+						"location_name": schema.StringAttribute{
+							Description: "Location name (city or state)",
+							Computed:    true,
+						},
+						"data_center_id": schema.StringAttribute{
+							Description: "ID of the data center",
+							Computed:    true,
+						},
+						"data_center_name": schema.StringAttribute{
+							Description: "Name of the data center",
+							Computed:    true,
+						},
+						"volume_gb": schema.Int64Attribute{
+							Description: "Volume size in gigabytes",
+							Computed:    true,
+						},
+						"volume_type": schema.StringAttribute{
+							Description: "Volume type (e.g., ssd, hdd)",
+							Computed:    true,
+						},
+						"price_per_unit": schema.Float64Attribute{
+							Description: "Price per unit for this configuration",
+							Computed:    true,
+						},
+						"price_currency": schema.StringAttribute{
+							Description: "Currency of the price",
+							Computed:    true,
+						},
+						"price_unit": schema.StringAttribute{
+							Description: "Billing unit for the price",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *systemVolumeConfigsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *systemVolumeConfigsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data systemVolumeConfigsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	apiReq := d.apiClient.VolumesConfigurationsAPI.GetSystemVolumeConfigs(auth)
+
+	if !data.AttachedToId.IsNull() && !data.AttachedToId.IsUnknown() {
+		apiReq = apiReq.AttachedToId(int32(data.AttachedToId.ValueInt64()))
+	}
+	if !data.VolumeGbMin.IsNull() && !data.VolumeGbMin.IsUnknown() {
+		apiReq = apiReq.VolumeGbMin(int32(data.VolumeGbMin.ValueInt64()))
+	}
+	if !data.VolumeType.IsNull() && !data.VolumeType.IsUnknown() {
+		apiReq = apiReq.VolumeType(data.VolumeType.ValueString())
+	}
+	apiReq = apiReq.Size(100)
+	configs, response, err := apiReq.Execute()
+
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read system volume configurations, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	configList, diags := convertSystemVolumeConfigsToList(ctx, configs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Configurations = configList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (o systemVolumeConfigurationModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"provider_id":      types.Int64Type,
+		"provider_name":    types.StringType,
+		"location_id":      types.Int64Type,
+		"location_name":    types.StringType,
+		"data_center_id":   types.StringType,
+		"data_center_name": types.StringType,
+		"volume_gb":        types.Int64Type,
+		"volume_type":      types.StringType,
+		"price_per_unit":   types.Float64Type,
+		"price_currency":   types.StringType,
+		"price_unit":       types.StringType,
+	}
+}
+
+func convertSystemVolumeConfigsToList(ctx context.Context, configs *emmaSdk.GetSystemVolumeConfigs200Response) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var configModels []systemVolumeConfigurationModel
+
+	if configs == nil || configs.Content == nil {
+		emptyList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: systemVolumeConfigurationModel{}.attrTypes()}, []systemVolumeConfigurationModel{})
+		diags.Append(listDiags...)
+		return emptyList, diags
+	}
+
+	for _, config := range configs.Content {
+		configModel := systemVolumeConfigurationModel{}
+
+		if config.ProviderId != nil {
+			configModel.ProviderId = types.Int64Value(int64(*config.ProviderId))
+		} else {
+			configModel.ProviderId = types.Int64Null()
+		}
+
+		if config.ProviderName != nil {
+			configModel.ProviderName = types.StringValue(*config.ProviderName)
+		} else {
+			configModel.ProviderName = types.StringNull()
+		}
+
+		if config.LocationId != nil {
+			configModel.LocationId = types.Int64Value(int64(*config.LocationId))
+		} else {
+			configModel.LocationId = types.Int64Null()
+		}
+
+		if config.LocationName != nil {
+			configModel.LocationName = types.StringValue(*config.LocationName)
+		} else {
+			configModel.LocationName = types.StringNull()
+		}
+
+		if config.DataCenterId != nil {
+			configModel.DataCenterId = types.StringValue(*config.DataCenterId)
+		} else {
+			configModel.DataCenterId = types.StringNull()
+		}
+
+		if config.DataCenterName != nil {
+			configModel.DataCenterName = types.StringValue(*config.DataCenterName)
+		} else {
+			configModel.DataCenterName = types.StringNull()
+		}
+
+		if config.VolumeGb != nil {
+			configModel.VolumeGb = types.Int64Value(int64(*config.VolumeGb))
+		} else {
+			configModel.VolumeGb = types.Int64Null()
+		}
+
+		if config.VolumeType != nil {
+			configModel.VolumeType = types.StringValue(*config.VolumeType)
+		} else {
+			configModel.VolumeType = types.StringNull()
+		}
+
+		if config.Cost != nil {
+			if config.Cost.PricePerUnit != nil {
+				configModel.PricePerUnit = types.Float64Value(float64(*config.Cost.PricePerUnit))
+			} else {
+				configModel.PricePerUnit = types.Float64Null()
+			}
+			if config.Cost.Currency != nil {
+				configModel.PriceCurrency = types.StringValue(*config.Cost.Currency)
+			} else {
+				configModel.PriceCurrency = types.StringNull()
+			}
+			if config.Cost.Unit != nil {
+				configModel.PriceUnit = types.StringValue(*config.Cost.Unit)
+			} else {
+				configModel.PriceUnit = types.StringNull()
+			}
+		} else {
+			configModel.PricePerUnit = types.Float64Null()
+			configModel.PriceCurrency = types.StringNull()
+			configModel.PriceUnit = types.StringNull()
+		}
+
+		configModels = append(configModels, configModel)
+	}
+
+	configList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: systemVolumeConfigurationModel{}.attrTypes()}, configModels)
+	diags.Append(listDiags...)
+
+	return configList, diags
+}

--- a/internal/emma/vm_configurations_data_source.go
+++ b/internal/emma/vm_configurations_data_source.go
@@ -1,0 +1,467 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &vmConfigurationsDataSource{}
+
+func NewVmConfigurationsDataSource() datasource.DataSource {
+	return &vmConfigurationsDataSource{}
+}
+
+// vmConfigurationsDataSource defines the data source implementation.
+type vmConfigurationsDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// vmConfigurationsDataSourceModel describes the data source data model.
+type vmConfigurationsDataSourceModel struct {
+	AcceleratorTypeId types.String  `tfsdk:"accelerator_type_id"`
+	DataCenterId      types.String  `tfsdk:"data_center_id"`
+	ProviderId        types.Int64   `tfsdk:"provider_id"`
+	VCpuType          types.String  `tfsdk:"vcpu_type"`
+	VCpuMin           types.Int64   `tfsdk:"vcpu_min"`
+	VCpuMax           types.Int64   `tfsdk:"vcpu_max"`
+	RamGbMin          types.Int64   `tfsdk:"ram_gb_min"`
+	RamGbMax          types.Int64   `tfsdk:"ram_gb_max"`
+	VolumeGbMin       types.Int64   `tfsdk:"volume_gb_min"`
+	VolumeGbMax       types.Int64   `tfsdk:"volume_gb_max"`
+	PriceMin          types.Float64 `tfsdk:"price_min"`
+	PriceMax          types.Float64 `tfsdk:"price_max"`
+	Configurations    types.List    `tfsdk:"configurations"`
+}
+
+// vmConfigurationModel describes individual configuration items in the list.
+type vmConfigurationModel struct {
+	ProviderId        types.Int64   `tfsdk:"provider_id"`
+	ProviderName      types.String  `tfsdk:"provider_name"`
+	LocationName      types.String  `tfsdk:"location_name"`
+	DataCenterId      types.String  `tfsdk:"data_center_id"`
+	DataCenterName    types.String  `tfsdk:"data_center_name"`
+	OsId              types.Int64   `tfsdk:"os_id"`
+	OsType            types.String  `tfsdk:"os_type"`
+	CloudNetworkTypes types.List    `tfsdk:"cloud_network_types"`
+	VCpuType          types.String  `tfsdk:"vcpu_type"`
+	VCpu              types.Int64   `tfsdk:"vcpu"`
+	RamGb             types.Int64   `tfsdk:"ram_gb"`
+	VolumeGb          types.Int64   `tfsdk:"volume_gb"`
+	VolumeType        types.String  `tfsdk:"volume_type"`
+	AcceleratorTypeId types.String  `tfsdk:"accelerator_type_id"`
+	AcceleratorType   types.String  `tfsdk:"accelerator_type"`
+	Accelerators      types.Float64 `tfsdk:"accelerators"`
+	PricePerUnit      types.Float64 `tfsdk:"price_per_unit"`
+	PriceCurrency     types.String  `tfsdk:"price_currency"`
+	PriceUnit         types.String  `tfsdk:"price_unit"`
+}
+
+func (d *vmConfigurationsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_vm_configurations"
+}
+
+func (d *vmConfigurationsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source retrieves available VM configurations in the Emma platform.\n\n" +
+			"Use this data source to discover valid VM types, CPU/RAM/storage options, GPU configurations, and pricing information when planning VM deployments.",
+		Attributes: map[string]schema.Attribute{
+			"accelerator_type_id": schema.StringAttribute{
+				Description: "GPU accelerator type ID to filter configurations",
+				Optional:    true,
+			},
+			"data_center_id": schema.StringAttribute{
+				Description: "ID of the data center to filter configurations",
+				Optional:    true,
+			},
+			"provider_id": schema.Int64Attribute{
+				Description: "ID of the cloud provider to filter configurations",
+				Optional:    true,
+			},
+			"vcpu_type": schema.StringAttribute{
+				Description: "vCPU type to filter configurations (shared, standard, hpc)",
+				Optional:    true,
+			},
+			"vcpu_min": schema.Int64Attribute{
+				Description: "Minimum number of vCPUs to filter configurations",
+				Optional:    true,
+			},
+			"vcpu_max": schema.Int64Attribute{
+				Description: "Maximum number of vCPUs to filter configurations",
+				Optional:    true,
+			},
+			"ram_gb_min": schema.Int64Attribute{
+				Description: "Minimum RAM in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"ram_gb_max": schema.Int64Attribute{
+				Description: "Maximum RAM in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"volume_gb_min": schema.Int64Attribute{
+				Description: "Minimum volume size in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"volume_gb_max": schema.Int64Attribute{
+				Description: "Maximum volume size in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"price_min": schema.Float64Attribute{
+				Description: "Minimum price to filter configurations",
+				Optional:    true,
+			},
+			"price_max": schema.Float64Attribute{
+				Description: "Maximum price to filter configurations",
+				Optional:    true,
+			},
+			"configurations": schema.ListNestedAttribute{
+				Description: "List of available VM configurations",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"provider_id": schema.Int64Attribute{
+							Description: "ID of the cloud provider",
+							Computed:    true,
+						},
+						"provider_name": schema.StringAttribute{
+							Description: "Name of the cloud provider",
+							Computed:    true,
+						},
+						"location_name": schema.StringAttribute{
+							Description: "Location name (city or region)",
+							Computed:    true,
+						},
+						"data_center_id": schema.StringAttribute{
+							Description: "ID of the data center",
+							Computed:    true,
+						},
+						"data_center_name": schema.StringAttribute{
+							Description: "Name of the data center",
+							Computed:    true,
+						},
+						"os_id": schema.Int64Attribute{
+							Description: "ID of the operating system",
+							Computed:    true,
+						},
+						"os_type": schema.StringAttribute{
+							Description: "Type of the operating system",
+							Computed:    true,
+						},
+						"cloud_network_types": schema.ListAttribute{
+							Description: "List of supported cloud network types",
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+						"vcpu_type": schema.StringAttribute{
+							Description: "vCPU type (shared, standard, hpc)",
+							Computed:    true,
+						},
+						"vcpu": schema.Int64Attribute{
+							Description: "Number of virtual CPUs",
+							Computed:    true,
+						},
+						"ram_gb": schema.Int64Attribute{
+							Description: "RAM in gigabytes",
+							Computed:    true,
+						},
+						"volume_gb": schema.Int64Attribute{
+							Description: "Volume size in gigabytes",
+							Computed:    true,
+						},
+						"volume_type": schema.StringAttribute{
+							Description: "Volume type (e.g., ssd, hdd)",
+							Computed:    true,
+						},
+						"accelerator_type_id": schema.StringAttribute{
+							Description: "GPU accelerator type ID",
+							Computed:    true,
+						},
+						"accelerator_type": schema.StringAttribute{
+							Description: "GPU accelerator type name",
+							Computed:    true,
+						},
+						"accelerators": schema.Float64Attribute{
+							Description: "Number of GPU accelerators",
+							Computed:    true,
+						},
+						"price_per_unit": schema.Float64Attribute{
+							Description: "Price per unit for this configuration",
+							Computed:    true,
+						},
+						"price_currency": schema.StringAttribute{
+							Description: "Currency of the price",
+							Computed:    true,
+						},
+						"price_unit": schema.StringAttribute{
+							Description: "Billing unit for the price",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *vmConfigurationsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *vmConfigurationsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data vmConfigurationsDataSourceModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	apiReq := d.apiClient.ComputeInstancesConfigurationsAPI.GetVmConfigs(auth)
+	if !data.AcceleratorTypeId.IsNull() {
+		apiReq = apiReq.AcceleratorTypeId(data.AcceleratorTypeId.ValueString())
+	}
+	if !data.DataCenterId.IsNull() {
+		apiReq = apiReq.DataCenterId(data.DataCenterId.ValueString())
+	}
+	if !data.ProviderId.IsNull() {
+		apiReq = apiReq.ProviderId(int32(data.ProviderId.ValueInt64()))
+	}
+	if !data.VCpuType.IsNull() {
+		apiReq = apiReq.VCpuType(data.VCpuType.ValueString())
+	}
+	if !data.VCpuMin.IsNull() {
+		apiReq = apiReq.VCpuMin(int32(data.VCpuMin.ValueInt64()))
+	}
+	if !data.VCpuMax.IsNull() {
+		apiReq = apiReq.VCpuMax(int32(data.VCpuMax.ValueInt64()))
+	}
+	if !data.RamGbMin.IsNull() {
+		apiReq = apiReq.RamGbMin(int32(data.RamGbMin.ValueInt64()))
+	}
+	if !data.RamGbMax.IsNull() {
+		apiReq = apiReq.RamGbMax(int32(data.RamGbMax.ValueInt64()))
+	}
+	if !data.VolumeGbMin.IsNull() {
+		apiReq = apiReq.VolumeGbMin(int32(data.VolumeGbMin.ValueInt64()))
+	}
+	if !data.VolumeGbMax.IsNull() {
+		apiReq = apiReq.VolumeGbMax(int32(data.VolumeGbMax.ValueInt64()))
+	}
+	if !data.PriceMin.IsNull() {
+		apiReq = apiReq.PriceMin(float32(data.PriceMin.ValueFloat64()))
+	}
+	if !data.PriceMax.IsNull() {
+		apiReq = apiReq.PriceMax(float32(data.PriceMax.ValueFloat64()))
+	}
+	apiReq = apiReq.Size(100)
+	configs, response, err := apiReq.Execute()
+
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read VM configurations, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	configList, diags := convertVmConfigsToList(ctx, configs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Configurations = configList
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Helper function to get attribute types for configuration nested object
+func (o vmConfigurationModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"provider_id":         types.Int64Type,
+		"provider_name":       types.StringType,
+		"location_name":       types.StringType,
+		"data_center_id":      types.StringType,
+		"data_center_name":    types.StringType,
+		"os_id":               types.Int64Type,
+		"os_type":             types.StringType,
+		"cloud_network_types": types.ListType{ElemType: types.StringType},
+		"vcpu_type":           types.StringType,
+		"vcpu":                types.Int64Type,
+		"ram_gb":              types.Int64Type,
+		"volume_gb":           types.Int64Type,
+		"volume_type":         types.StringType,
+		"accelerator_type_id": types.StringType,
+		"accelerator_type":    types.StringType,
+		"accelerators":        types.Float64Type,
+		"price_per_unit":      types.Float64Type,
+		"price_currency":      types.StringType,
+		"price_unit":          types.StringType,
+	}
+}
+
+// convertVmConfigsToList converts Emma API VM configurations response to Terraform list
+func convertVmConfigsToList(ctx context.Context, configs *emmaSdk.GetVmConfigs200Response) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var configModels []vmConfigurationModel
+
+	// Check if configs is nil or has no content
+	if configs == nil || configs.Content == nil {
+		emptyList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: vmConfigurationModel{}.attrTypes()}, []vmConfigurationModel{})
+		diags.Append(listDiags...)
+		return emptyList, diags
+	}
+
+	for _, config := range configs.Content {
+		configModel := vmConfigurationModel{}
+
+		if config.ProviderId != nil {
+			configModel.ProviderId = types.Int64Value(int64(*config.ProviderId))
+		} else {
+			configModel.ProviderId = types.Int64Null()
+		}
+
+		if config.ProviderName != nil {
+			configModel.ProviderName = types.StringValue(*config.ProviderName)
+		} else {
+			configModel.ProviderName = types.StringNull()
+		}
+
+		if config.LocationName != nil {
+			configModel.LocationName = types.StringValue(*config.LocationName)
+		} else {
+			configModel.LocationName = types.StringNull()
+		}
+
+		if config.DataCenterId != nil {
+			configModel.DataCenterId = types.StringValue(*config.DataCenterId)
+		} else {
+			configModel.DataCenterId = types.StringNull()
+		}
+
+		if config.DataCenterName != nil {
+			configModel.DataCenterName = types.StringValue(*config.DataCenterName)
+		} else {
+			configModel.DataCenterName = types.StringNull()
+		}
+
+		if config.OsId != nil {
+			configModel.OsId = types.Int64Value(int64(*config.OsId))
+		} else {
+			configModel.OsId = types.Int64Null()
+		}
+
+		if config.OsType != nil {
+			configModel.OsType = types.StringValue(*config.OsType)
+		} else {
+			configModel.OsType = types.StringNull()
+		}
+
+		cloudNetworkTypesList, listDiags := types.ListValueFrom(ctx, types.StringType, config.CloudNetworkTypes)
+		diags.Append(listDiags...)
+		configModel.CloudNetworkTypes = cloudNetworkTypesList
+
+		if config.VCpuType != nil {
+			configModel.VCpuType = types.StringValue(*config.VCpuType)
+		} else {
+			configModel.VCpuType = types.StringNull()
+		}
+
+		if config.VCpu != nil {
+			configModel.VCpu = types.Int64Value(int64(*config.VCpu))
+		} else {
+			configModel.VCpu = types.Int64Null()
+		}
+
+		if config.RamGb != nil {
+			configModel.RamGb = types.Int64Value(int64(*config.RamGb))
+		} else {
+			configModel.RamGb = types.Int64Null()
+		}
+
+		if config.VolumeGb != nil {
+			configModel.VolumeGb = types.Int64Value(int64(*config.VolumeGb))
+		} else {
+			configModel.VolumeGb = types.Int64Null()
+		}
+
+		if config.VolumeType != nil {
+			configModel.VolumeType = types.StringValue(*config.VolumeType)
+		} else {
+			configModel.VolumeType = types.StringNull()
+		}
+
+		if config.Accelerator != nil {
+			if config.Accelerator.AcceleratorTypeId != nil {
+				configModel.AcceleratorTypeId = types.StringValue(*config.Accelerator.AcceleratorTypeId)
+			} else {
+				configModel.AcceleratorTypeId = types.StringNull()
+			}
+			if config.Accelerator.AcceleratorType != nil {
+				configModel.AcceleratorType = types.StringValue(*config.Accelerator.AcceleratorType)
+			} else {
+				configModel.AcceleratorType = types.StringNull()
+			}
+			if config.Accelerator.Accelerators != nil {
+				configModel.Accelerators = types.Float64Value(float64(*config.Accelerator.Accelerators))
+			} else {
+				configModel.Accelerators = types.Float64Null()
+			}
+		} else {
+			configModel.AcceleratorTypeId = types.StringNull()
+			configModel.AcceleratorType = types.StringNull()
+			configModel.Accelerators = types.Float64Null()
+		}
+
+		if config.Cost != nil {
+			if config.Cost.PricePerUnit != nil {
+				configModel.PricePerUnit = types.Float64Value(float64(*config.Cost.PricePerUnit))
+			} else {
+				configModel.PricePerUnit = types.Float64Null()
+			}
+			if config.Cost.Currency != nil {
+				configModel.PriceCurrency = types.StringValue(*config.Cost.Currency)
+			} else {
+				configModel.PriceCurrency = types.StringNull()
+			}
+			if config.Cost.Unit != nil {
+				configModel.PriceUnit = types.StringValue(*config.Cost.Unit)
+			} else {
+				configModel.PriceUnit = types.StringNull()
+			}
+		} else {
+			configModel.PricePerUnit = types.Float64Null()
+			configModel.PriceCurrency = types.StringNull()
+			configModel.PriceUnit = types.StringNull()
+		}
+
+		configModels = append(configModels, configModel)
+	}
+
+	// Convert to Terraform list
+	configList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: vmConfigurationModel{}.attrTypes()}, configModels)
+	diags.Append(listDiags...)
+
+	return configList, diags
+}

--- a/internal/emma/vm_resize_configs_data_source.go
+++ b/internal/emma/vm_resize_configs_data_source.go
@@ -1,0 +1,319 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &vmResizeConfigsDataSource{}
+
+func NewVmResizeConfigsDataSource() datasource.DataSource {
+	return &vmResizeConfigsDataSource{}
+}
+
+type vmResizeConfigsDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+type vmResizeConfigsDataSourceModel struct {
+	VmId           types.Int64   `tfsdk:"vm_id"`
+	VCpuType       types.String  `tfsdk:"vcpu_type"`
+	VCpuMin        types.Int64   `tfsdk:"vcpu_min"`
+	VCpuMax        types.Int64   `tfsdk:"vcpu_max"`
+	RamGbMin       types.Int64   `tfsdk:"ram_gb_min"`
+	RamGbMax       types.Int64   `tfsdk:"ram_gb_max"`
+	PriceMin       types.Float64 `tfsdk:"price_min"`
+	PriceMax       types.Float64 `tfsdk:"price_max"`
+	Configurations types.List    `tfsdk:"configurations"`
+}
+
+type vmResizeConfigurationModel struct {
+	VCpuType            types.String  `tfsdk:"vcpu_type"`
+	VCpu                types.Int64   `tfsdk:"vcpu"`
+	RamGb               types.Int64   `tfsdk:"ram_gb"`
+	ProviderComputeType types.String  `tfsdk:"provider_compute_type"`
+	AcceleratorTypeId   types.String  `tfsdk:"accelerator_type_id"`
+	AcceleratorType     types.String  `tfsdk:"accelerator_type"`
+	Accelerators        types.Float64 `tfsdk:"accelerators"`
+	PricePerUnit        types.Float64 `tfsdk:"price_per_unit"`
+	PriceCurrency       types.String  `tfsdk:"price_currency"`
+	PriceUnit           types.String  `tfsdk:"price_unit"`
+}
+
+func (d *vmResizeConfigsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_vm_resize_configs"
+}
+
+func (d *vmResizeConfigsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This data source retrieves available hardware configurations for virtual machine resizing in the Emma platform.\n\n" +
+			"Use this data source to discover valid resize configurations for an existing VM before calling the VM edit endpoint.",
+		Attributes: map[string]schema.Attribute{
+			"vm_id": schema.Int64Attribute{
+				Description: "ID of the virtual machine to retrieve resize configurations for",
+				Optional:    true,
+			},
+			"vcpu_type": schema.StringAttribute{
+				Description: "vCPU type to filter configurations (shared, standard, hpc)",
+				Optional:    true,
+			},
+			"vcpu_min": schema.Int64Attribute{
+				Description: "Minimum number of vCPUs to filter configurations",
+				Optional:    true,
+			},
+			"vcpu_max": schema.Int64Attribute{
+				Description: "Maximum number of vCPUs to filter configurations",
+				Optional:    true,
+			},
+			"ram_gb_min": schema.Int64Attribute{
+				Description: "Minimum RAM in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"ram_gb_max": schema.Int64Attribute{
+				Description: "Maximum RAM in gigabytes to filter configurations",
+				Optional:    true,
+			},
+			"price_min": schema.Float64Attribute{
+				Description: "Minimum price to filter configurations",
+				Optional:    true,
+			},
+			"price_max": schema.Float64Attribute{
+				Description: "Maximum price to filter configurations",
+				Optional:    true,
+			},
+			"configurations": schema.ListNestedAttribute{
+				Description: "List of available VM resize configurations",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"vcpu_type": schema.StringAttribute{
+							Description: "vCPU type (shared, standard, hpc)",
+							Computed:    true,
+						},
+						"vcpu": schema.Int64Attribute{
+							Description: "Number of virtual CPUs",
+							Computed:    true,
+						},
+						"ram_gb": schema.Int64Attribute{
+							Description: "RAM in gigabytes",
+							Computed:    true,
+						},
+						"provider_compute_type": schema.StringAttribute{
+							Description: "Provider-specific compute type identifier",
+							Computed:    true,
+						},
+						"accelerator_type_id": schema.StringAttribute{
+							Description: "GPU accelerator type ID",
+							Computed:    true,
+						},
+						"accelerator_type": schema.StringAttribute{
+							Description: "GPU accelerator type name",
+							Computed:    true,
+						},
+						"accelerators": schema.Float64Attribute{
+							Description: "Number of GPU accelerators",
+							Computed:    true,
+						},
+						"price_per_unit": schema.Float64Attribute{
+							Description: "Price per unit for this configuration",
+							Computed:    true,
+						},
+						"price_currency": schema.StringAttribute{
+							Description: "Currency of the price",
+							Computed:    true,
+						},
+						"price_unit": schema.StringAttribute{
+							Description: "Billing unit for the price",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *vmResizeConfigsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *vmResizeConfigsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data vmResizeConfigsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	apiReq := d.apiClient.ComputeInstancesConfigurationsAPI.GetVmResizeConfigs(auth)
+
+	if !data.VmId.IsNull() && !data.VmId.IsUnknown() {
+		apiReq = apiReq.VmId(int32(data.VmId.ValueInt64()))
+	}
+	if !data.VCpuType.IsNull() && !data.VCpuType.IsUnknown() {
+		apiReq = apiReq.VCpuType(data.VCpuType.ValueString())
+	}
+	if !data.VCpuMin.IsNull() && !data.VCpuMin.IsUnknown() {
+		apiReq = apiReq.VCpuMin(int32(data.VCpuMin.ValueInt64()))
+	}
+	if !data.VCpuMax.IsNull() && !data.VCpuMax.IsUnknown() {
+		apiReq = apiReq.VCpuMax(int32(data.VCpuMax.ValueInt64()))
+	}
+	if !data.RamGbMin.IsNull() && !data.RamGbMin.IsUnknown() {
+		apiReq = apiReq.RamGbMin(int32(data.RamGbMin.ValueInt64()))
+	}
+	if !data.RamGbMax.IsNull() && !data.RamGbMax.IsUnknown() {
+		apiReq = apiReq.RamGbMax(int32(data.RamGbMax.ValueInt64()))
+	}
+	if !data.PriceMin.IsNull() && !data.PriceMin.IsUnknown() {
+		apiReq = apiReq.PriceMin(float32(data.PriceMin.ValueFloat64()))
+	}
+	if !data.PriceMax.IsNull() && !data.PriceMax.IsUnknown() {
+		apiReq = apiReq.PriceMax(float32(data.PriceMax.ValueFloat64()))
+	}
+	apiReq = apiReq.Size(100)
+	configs, response, err := apiReq.Execute()
+
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read VM resize configurations, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	configList, diags := convertVmResizeConfigsToList(ctx, configs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Configurations = configList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (o vmResizeConfigurationModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"vcpu_type":             types.StringType,
+		"vcpu":                  types.Int64Type,
+		"ram_gb":                types.Int64Type,
+		"provider_compute_type": types.StringType,
+		"accelerator_type_id":   types.StringType,
+		"accelerator_type":      types.StringType,
+		"accelerators":          types.Float64Type,
+		"price_per_unit":        types.Float64Type,
+		"price_currency":        types.StringType,
+		"price_unit":            types.StringType,
+	}
+}
+
+func convertVmResizeConfigsToList(ctx context.Context, configs *emmaSdk.GetVmResizeConfigs200Response) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var configModels []vmResizeConfigurationModel
+
+	if configs == nil || configs.Content == nil {
+		emptyList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: vmResizeConfigurationModel{}.attrTypes()}, []vmResizeConfigurationModel{})
+		diags.Append(listDiags...)
+		return emptyList, diags
+	}
+
+	for _, config := range configs.Content {
+		configModel := vmResizeConfigurationModel{}
+
+		if config.VCpuType != nil {
+			configModel.VCpuType = types.StringValue(*config.VCpuType)
+		} else {
+			configModel.VCpuType = types.StringNull()
+		}
+
+		if config.VCpu != nil {
+			configModel.VCpu = types.Int64Value(int64(*config.VCpu))
+		} else {
+			configModel.VCpu = types.Int64Null()
+		}
+
+		if config.RamGb != nil {
+			configModel.RamGb = types.Int64Value(int64(*config.RamGb))
+		} else {
+			configModel.RamGb = types.Int64Null()
+		}
+
+		if config.ProviderComputeType != nil {
+			configModel.ProviderComputeType = types.StringValue(*config.ProviderComputeType)
+		} else {
+			configModel.ProviderComputeType = types.StringNull()
+		}
+
+		if config.Accelerator != nil {
+			if config.Accelerator.AcceleratorTypeId != nil {
+				configModel.AcceleratorTypeId = types.StringValue(*config.Accelerator.AcceleratorTypeId)
+			} else {
+				configModel.AcceleratorTypeId = types.StringNull()
+			}
+			if config.Accelerator.AcceleratorType != nil {
+				configModel.AcceleratorType = types.StringValue(*config.Accelerator.AcceleratorType)
+			} else {
+				configModel.AcceleratorType = types.StringNull()
+			}
+			if config.Accelerator.Accelerators != nil {
+				configModel.Accelerators = types.Float64Value(float64(*config.Accelerator.Accelerators))
+			} else {
+				configModel.Accelerators = types.Float64Null()
+			}
+		} else {
+			configModel.AcceleratorTypeId = types.StringNull()
+			configModel.AcceleratorType = types.StringNull()
+			configModel.Accelerators = types.Float64Null()
+		}
+
+		if config.Cost != nil {
+			if config.Cost.PricePerUnit != nil {
+				configModel.PricePerUnit = types.Float64Value(float64(*config.Cost.PricePerUnit))
+			} else {
+				configModel.PricePerUnit = types.Float64Null()
+			}
+			if config.Cost.Currency != nil {
+				configModel.PriceCurrency = types.StringValue(*config.Cost.Currency)
+			} else {
+				configModel.PriceCurrency = types.StringNull()
+			}
+			if config.Cost.Unit != nil {
+				configModel.PriceUnit = types.StringValue(*config.Cost.Unit)
+			} else {
+				configModel.PriceUnit = types.StringNull()
+			}
+		} else {
+			configModel.PricePerUnit = types.Float64Null()
+			configModel.PriceCurrency = types.StringNull()
+			configModel.PriceUnit = types.StringNull()
+		}
+
+		configModels = append(configModels, configModel)
+	}
+
+	configList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: vmResizeConfigurationModel{}.attrTypes()}, configModels)
+	diags.Append(listDiags...)
+
+	return configList, diags
+}

--- a/internal/emma/vm_resize_configs_data_source.go
+++ b/internal/emma/vm_resize_configs_data_source.go
@@ -58,8 +58,8 @@ func (d *vmResizeConfigsDataSource) Schema(ctx context.Context, req datasource.S
 			"Use this data source to discover valid resize configurations for an existing VM before calling the VM edit endpoint.",
 		Attributes: map[string]schema.Attribute{
 			"vm_id": schema.Int64Attribute{
-				Description: "ID of the virtual machine to retrieve resize configurations for",
-				Optional:    true,
+				Description: "ID of the virtual machine to retrieve resize configurations for. Required by the server.",
+				Required:    true,
 			},
 			"vcpu_type": schema.StringAttribute{
 				Description: "vCPU type to filter configurations (shared, standard, hpc)",
@@ -168,9 +168,7 @@ func (d *vmResizeConfigsDataSource) Read(ctx context.Context, req datasource.Rea
 	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
 	apiReq := d.apiClient.ComputeInstancesConfigurationsAPI.GetVmResizeConfigs(auth)
 
-	if !data.VmId.IsNull() && !data.VmId.IsUnknown() {
-		apiReq = apiReq.VmId(int32(data.VmId.ValueInt64()))
-	}
+	apiReq = apiReq.VmId(int32(data.VmId.ValueInt64()))
 	if !data.VCpuType.IsNull() && !data.VCpuType.IsUnknown() {
 		apiReq = apiReq.VCpuType(data.VCpuType.ValueString())
 	}

--- a/internal/emma/vm_resource.go
+++ b/internal/emma/vm_resource.go
@@ -1031,13 +1031,20 @@ func ConvertVmResponseToResource(ctx context.Context, stateData *vmResourceModel
 	if vm.Accelerator != nil {
 		if vm.Accelerator.AcceleratorTypeId != nil {
 			stateData.AcceleratorTypeId = types.StringValue(*vm.Accelerator.AcceleratorTypeId)
+		} else {
+			stateData.AcceleratorTypeId = types.StringNull()
 		}
 		if vm.Accelerator.Accelerators != nil {
 			stateData.Accelerators = types.Float64Value(float64(*vm.Accelerator.Accelerators))
+		} else {
+			stateData.Accelerators = types.Float64Null()
 		}
 	} else if planData != nil {
 		stateData.AcceleratorTypeId = planData.AcceleratorTypeId
 		stateData.Accelerators = planData.Accelerators
+	} else {
+		stateData.AcceleratorTypeId = types.StringNull()
+		stateData.Accelerators = types.Float64Null()
 	}
 
 	// Preserve create-only fields from plan

--- a/internal/emma/vms_data_source.go
+++ b/internal/emma/vms_data_source.go
@@ -216,7 +216,7 @@ func (o vmItemModel) attrTypes() map[string]attr.Type {
 // convertVmsToList converts Emma API VMs response to Terraform list
 func convertVmsToList(ctx context.Context, vms []emmaSdk.Vm) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var itemModels []vmItemModel
+	itemModels := make([]vmItemModel, 0, len(vms))
 
 	for _, vm := range vms {
 		item := vmItemModel{}

--- a/internal/emma/vms_data_source.go
+++ b/internal/emma/vms_data_source.go
@@ -1,0 +1,349 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &vmsDataSource{}
+
+func NewVmsDataSource() datasource.DataSource {
+	return &vmsDataSource{}
+}
+
+// vmsDataSource defines the data source implementation.
+type vmsDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// vmsDataSourceModel describes the data source data model.
+type vmsDataSourceModel struct {
+	ProjectId types.Int64 `tfsdk:"project_id"`
+	Vms       types.List  `tfsdk:"vms"`
+}
+
+// vmItemModel describes individual VM items in the list.
+type vmItemModel struct {
+	Id               types.Int64   `tfsdk:"id"`
+	Name             types.String  `tfsdk:"name"`
+	Status           types.String  `tfsdk:"status"`
+	ProjectId        types.Int64   `tfsdk:"project_id"`
+	ProviderId       types.Int64   `tfsdk:"provider_id"`
+	ProviderName     types.String  `tfsdk:"provider_name"`
+	LocationId       types.Int64   `tfsdk:"location_id"`
+	LocationName     types.String  `tfsdk:"location_name"`
+	DataCenterId     types.String  `tfsdk:"data_center_id"`
+	DataCenterName   types.String  `tfsdk:"data_center_name"`
+	OsId             types.Int64   `tfsdk:"os_id"`
+	OsType           types.String  `tfsdk:"os_type"`
+	VCpu             types.Int64   `tfsdk:"vcpu"`
+	VCpuType         types.String  `tfsdk:"vcpu_type"`
+	RamGb            types.Int64   `tfsdk:"ram_gb"`
+	CloudNetworkType types.String  `tfsdk:"cloud_network_type"`
+	CreatedAt        types.String  `tfsdk:"created_at"`
+}
+
+func (d *vmsDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_vms"
+}
+
+func (d *vmsDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a list of virtual machines in the Emma platform. Optionally filter by project ID.",
+		Attributes: map[string]schema.Attribute{
+			"project_id": schema.Int64Attribute{
+				Description: "Project ID to filter virtual machines",
+				Optional:    true,
+			},
+			"vms": schema.ListNestedAttribute{
+				Description: "List of virtual machines",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.Int64Attribute{
+							Description: "ID of the virtual machine",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "Name of the virtual machine",
+							Computed:    true,
+						},
+						"status": schema.StringAttribute{
+							Description: "Status of the virtual machine",
+							Computed:    true,
+						},
+						"project_id": schema.Int64Attribute{
+							Description: "Project ID the virtual machine belongs to",
+							Computed:    true,
+						},
+						"provider_id": schema.Int64Attribute{
+							Description: "ID of the cloud provider",
+							Computed:    true,
+						},
+						"provider_name": schema.StringAttribute{
+							Description: "Name of the cloud provider",
+							Computed:    true,
+						},
+						"location_id": schema.Int64Attribute{
+							Description: "ID of the data center location",
+							Computed:    true,
+						},
+						"location_name": schema.StringAttribute{
+							Description: "Name of the data center location",
+							Computed:    true,
+						},
+						"data_center_id": schema.StringAttribute{
+							Description: "ID of the data center",
+							Computed:    true,
+						},
+						"data_center_name": schema.StringAttribute{
+							Description: "Name of the data center",
+							Computed:    true,
+						},
+						"os_id": schema.Int64Attribute{
+							Description: "ID of the operating system",
+							Computed:    true,
+						},
+						"os_type": schema.StringAttribute{
+							Description: "Type of the operating system",
+							Computed:    true,
+						},
+						"vcpu": schema.Int64Attribute{
+							Description: "Number of virtual CPUs",
+							Computed:    true,
+						},
+						"vcpu_type": schema.StringAttribute{
+							Description: "Type of virtual CPUs (shared, standard, hpc)",
+							Computed:    true,
+						},
+						"ram_gb": schema.Int64Attribute{
+							Description: "RAM in gigabytes",
+							Computed:    true,
+						},
+						"cloud_network_type": schema.StringAttribute{
+							Description: "Cloud network type of the virtual machine",
+							Computed:    true,
+						},
+						"created_at": schema.StringAttribute{
+							Description: "Date and time when the virtual machine was created",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *vmsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *vmsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data vmsDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	apiReq := d.apiClient.VirtualMachinesAPI.GetVms(auth)
+	if !data.ProjectId.IsNull() {
+		apiReq = apiReq.ProjectId(int32(data.ProjectId.ValueInt64()))
+	}
+	vms, response, err := apiReq.Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read virtual machines, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	vmList, diags := convertVmsToList(ctx, vms)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Vms = vmList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Helper function to get attribute types for VM nested object
+func (o vmItemModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":                 types.Int64Type,
+		"name":               types.StringType,
+		"status":             types.StringType,
+		"project_id":         types.Int64Type,
+		"provider_id":        types.Int64Type,
+		"provider_name":      types.StringType,
+		"location_id":        types.Int64Type,
+		"location_name":      types.StringType,
+		"data_center_id":     types.StringType,
+		"data_center_name":   types.StringType,
+		"os_id":              types.Int64Type,
+		"os_type":            types.StringType,
+		"vcpu":               types.Int64Type,
+		"vcpu_type":          types.StringType,
+		"ram_gb":             types.Int64Type,
+		"cloud_network_type": types.StringType,
+		"created_at":         types.StringType,
+	}
+}
+
+// convertVmsToList converts Emma API VMs response to Terraform list
+func convertVmsToList(ctx context.Context, vms []emmaSdk.Vm) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var itemModels []vmItemModel
+
+	for _, vm := range vms {
+		item := vmItemModel{}
+
+		if vm.Id != nil {
+			item.Id = types.Int64Value(int64(*vm.Id))
+		} else {
+			item.Id = types.Int64Null()
+		}
+
+		if vm.Name != nil {
+			item.Name = types.StringValue(*vm.Name)
+		} else {
+			item.Name = types.StringNull()
+		}
+
+		if vm.Status != nil {
+			item.Status = types.StringValue(*vm.Status)
+		} else {
+			item.Status = types.StringNull()
+		}
+
+		if vm.ProjectId != nil {
+			item.ProjectId = types.Int64Value(int64(*vm.ProjectId))
+		} else {
+			item.ProjectId = types.Int64Null()
+		}
+
+		if vm.Provider != nil {
+			if vm.Provider.Id != nil {
+				item.ProviderId = types.Int64Value(int64(*vm.Provider.Id))
+			} else {
+				item.ProviderId = types.Int64Null()
+			}
+			if vm.Provider.Name != nil {
+				item.ProviderName = types.StringValue(*vm.Provider.Name)
+			} else {
+				item.ProviderName = types.StringNull()
+			}
+		} else {
+			item.ProviderId = types.Int64Null()
+			item.ProviderName = types.StringNull()
+		}
+
+		if vm.Location != nil {
+			if vm.Location.Id != nil {
+				item.LocationId = types.Int64Value(int64(*vm.Location.Id))
+			} else {
+				item.LocationId = types.Int64Null()
+			}
+			if vm.Location.Name != nil {
+				item.LocationName = types.StringValue(*vm.Location.Name)
+			} else {
+				item.LocationName = types.StringNull()
+			}
+		} else {
+			item.LocationId = types.Int64Null()
+			item.LocationName = types.StringNull()
+		}
+
+		if vm.DataCenter != nil {
+			if vm.DataCenter.Id != nil {
+				item.DataCenterId = types.StringValue(*vm.DataCenter.Id)
+			} else {
+				item.DataCenterId = types.StringNull()
+			}
+			if vm.DataCenter.Name != nil {
+				item.DataCenterName = types.StringValue(*vm.DataCenter.Name)
+			} else {
+				item.DataCenterName = types.StringNull()
+			}
+		} else {
+			item.DataCenterId = types.StringNull()
+			item.DataCenterName = types.StringNull()
+		}
+
+		if vm.Os != nil {
+			if vm.Os.Id != nil {
+				item.OsId = types.Int64Value(int64(*vm.Os.Id))
+			} else {
+				item.OsId = types.Int64Null()
+			}
+			if vm.Os.Type != nil {
+				item.OsType = types.StringValue(*vm.Os.Type)
+			} else {
+				item.OsType = types.StringNull()
+			}
+		} else {
+			item.OsId = types.Int64Null()
+			item.OsType = types.StringNull()
+		}
+
+		if vm.VCpu != nil {
+			item.VCpu = types.Int64Value(int64(*vm.VCpu))
+		} else {
+			item.VCpu = types.Int64Null()
+		}
+
+		if vm.VCpuType != nil {
+			item.VCpuType = types.StringValue(*vm.VCpuType)
+		} else {
+			item.VCpuType = types.StringNull()
+		}
+
+		if vm.RamGb != nil {
+			item.RamGb = types.Int64Value(int64(*vm.RamGb))
+		} else {
+			item.RamGb = types.Int64Null()
+		}
+
+		if vm.CloudNetworkType != nil {
+			item.CloudNetworkType = types.StringValue(*vm.CloudNetworkType)
+		} else {
+			item.CloudNetworkType = types.StringNull()
+		}
+
+		if vm.CreatedAt != nil {
+			item.CreatedAt = types.StringValue(*vm.CreatedAt)
+		} else {
+			item.CreatedAt = types.StringNull()
+		}
+
+		itemModels = append(itemModels, item)
+	}
+
+	vmList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: vmItemModel{}.attrTypes()}, itemModels)
+	diags.Append(listDiags...)
+
+	return vmList, diags
+}

--- a/internal/emma/volumes_data_source.go
+++ b/internal/emma/volumes_data_source.go
@@ -195,7 +195,7 @@ func (o volumeItemModel) attrTypes() map[string]attr.Type {
 // convertVolumesToList converts Emma API volumes response to Terraform list
 func convertVolumesToList(ctx context.Context, volumes []emmaSdk.Volume) (types.List, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var itemModels []volumeItemModel
+	itemModels := make([]volumeItemModel, 0, len(volumes))
 
 	for _, v := range volumes {
 		item := volumeItemModel{}

--- a/internal/emma/volumes_data_source.go
+++ b/internal/emma/volumes_data_source.go
@@ -1,0 +1,300 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &volumesDataSource{}
+
+func NewVolumesDataSource() datasource.DataSource {
+	return &volumesDataSource{}
+}
+
+// volumesDataSource defines the data source implementation.
+type volumesDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+// volumesDataSourceModel describes the data source data model.
+type volumesDataSourceModel struct {
+	Volumes types.List `tfsdk:"volumes"`
+}
+
+// volumeItemModel describes individual volume items in the list.
+type volumeItemModel struct {
+	Id             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	SizeGb         types.Int64  `tfsdk:"size_gb"`
+	VolumeType     types.String `tfsdk:"volume_type"`
+	IsSystem       types.Bool   `tfsdk:"is_system"`
+	Status         types.String `tfsdk:"status"`
+	AttachedToId   types.Int64  `tfsdk:"attached_to_id"`
+	ProjectId      types.Int64  `tfsdk:"project_id"`
+	DataCenterId   types.String `tfsdk:"data_center_id"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	CreatedByName  types.String `tfsdk:"created_by_name"`
+	CreatedById    types.Int64  `tfsdk:"created_by_id"`
+	ModifiedAt     types.String `tfsdk:"modified_at"`
+	ModifiedByName types.String `tfsdk:"modified_by_name"`
+	ModifiedById   types.Int64  `tfsdk:"modified_by_id"`
+}
+
+func (d *volumesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_volumes"
+}
+
+func (d *volumesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a list of all storage volumes in the project.",
+		Attributes: map[string]schema.Attribute{
+			"volumes": schema.ListNestedAttribute{
+				Description: "List of volumes",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "Volume ID",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "Volume name",
+							Computed:    true,
+						},
+						"size_gb": schema.Int64Attribute{
+							Description: "Volume size in gigabytes",
+							Computed:    true,
+						},
+						"volume_type": schema.StringAttribute{
+							Description: "Volume type (e.g., ssd, hdd)",
+							Computed:    true,
+						},
+						"is_system": schema.BoolAttribute{
+							Description: "Indicates whether the volume contains the operating system",
+							Computed:    true,
+						},
+						"status": schema.StringAttribute{
+							Description: "Current status of the volume",
+							Computed:    true,
+						},
+						"attached_to_id": schema.Int64Attribute{
+							Description: "ID of the compute instance the volume is attached to",
+							Computed:    true,
+						},
+						"project_id": schema.Int64Attribute{
+							Description: "Project ID owning the volume",
+							Computed:    true,
+						},
+						"data_center_id": schema.StringAttribute{
+							Description: "Data center ID where the volume is located",
+							Computed:    true,
+						},
+						"created_at": schema.StringAttribute{
+							Description: "Creation timestamp",
+							Computed:    true,
+						},
+						"created_by_name": schema.StringAttribute{
+							Description: "Name of the user who created the volume",
+							Computed:    true,
+						},
+						"created_by_id": schema.Int64Attribute{
+							Description: "ID of the user who created the volume",
+							Computed:    true,
+						},
+						"modified_at": schema.StringAttribute{
+							Description: "Date and time when the volume was last modified",
+							Computed:    true,
+						},
+						"modified_by_name": schema.StringAttribute{
+							Description: "Name of the user who last modified the volume",
+							Computed:    true,
+						},
+						"modified_by_id": schema.Int64Attribute{
+							Description: "ID of the user who last modified the volume",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *volumesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *volumesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data volumesDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+	volumes, response, err := d.apiClient.VolumesAPI.GetVolumes(auth).Execute()
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read volumes, got error: %s",
+				tools.ExtractErrorMessage(response)))
+		return
+	}
+
+	volumeList, diags := convertVolumesToList(ctx, volumes)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Volumes = volumeList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Helper function to get attribute types for volume nested object
+func (o volumeItemModel) attrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":               types.StringType,
+		"name":             types.StringType,
+		"size_gb":          types.Int64Type,
+		"volume_type":      types.StringType,
+		"is_system":        types.BoolType,
+		"status":           types.StringType,
+		"attached_to_id":   types.Int64Type,
+		"project_id":       types.Int64Type,
+		"data_center_id":   types.StringType,
+		"created_at":       types.StringType,
+		"created_by_name":  types.StringType,
+		"created_by_id":    types.Int64Type,
+		"modified_at":      types.StringType,
+		"modified_by_name": types.StringType,
+		"modified_by_id":   types.Int64Type,
+	}
+}
+
+// convertVolumesToList converts Emma API volumes response to Terraform list
+func convertVolumesToList(ctx context.Context, volumes []emmaSdk.Volume) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	var itemModels []volumeItemModel
+
+	for _, v := range volumes {
+		item := volumeItemModel{}
+
+		if v.Id != nil {
+			item.Id = types.StringValue(fmt.Sprintf("%d", *v.Id))
+		} else {
+			item.Id = types.StringNull()
+		}
+
+		if v.Name != nil {
+			item.Name = types.StringValue(*v.Name)
+		} else {
+			item.Name = types.StringNull()
+		}
+
+		if v.SizeGb != nil {
+			item.SizeGb = types.Int64Value(int64(*v.SizeGb))
+		} else {
+			item.SizeGb = types.Int64Null()
+		}
+
+		if v.Type != nil {
+			item.VolumeType = types.StringValue(*v.Type)
+		} else {
+			item.VolumeType = types.StringNull()
+		}
+
+		if v.IsSystem != nil {
+			item.IsSystem = types.BoolValue(*v.IsSystem)
+		} else {
+			item.IsSystem = types.BoolNull()
+		}
+
+		if v.Status != nil {
+			item.Status = types.StringValue(*v.Status)
+		} else {
+			item.Status = types.StringNull()
+		}
+
+		if v.AttachedToId != nil {
+			item.AttachedToId = types.Int64Value(int64(*v.AttachedToId))
+		} else {
+			item.AttachedToId = types.Int64Null()
+		}
+
+		if v.ProjectId != nil {
+			item.ProjectId = types.Int64Value(int64(*v.ProjectId))
+		} else {
+			item.ProjectId = types.Int64Null()
+		}
+
+		if v.DataCenter != nil && v.DataCenter.Id != nil {
+			item.DataCenterId = types.StringValue(*v.DataCenter.Id)
+		} else {
+			item.DataCenterId = types.StringNull()
+		}
+
+		if v.CreatedAt != nil {
+			item.CreatedAt = types.StringValue(*v.CreatedAt)
+		} else {
+			item.CreatedAt = types.StringNull()
+		}
+
+		if v.CreatedByName != nil {
+			item.CreatedByName = types.StringValue(*v.CreatedByName)
+		} else {
+			item.CreatedByName = types.StringNull()
+		}
+
+		if v.CreatedById != nil {
+			item.CreatedById = types.Int64Value(int64(*v.CreatedById))
+		} else {
+			item.CreatedById = types.Int64Null()
+		}
+
+		if v.ModifiedAt != nil {
+			item.ModifiedAt = types.StringValue(*v.ModifiedAt)
+		} else {
+			item.ModifiedAt = types.StringNull()
+		}
+
+		if v.ModifiedByName != nil {
+			item.ModifiedByName = types.StringValue(*v.ModifiedByName)
+		} else {
+			item.ModifiedByName = types.StringNull()
+		}
+
+		if v.ModifiedById != nil {
+			item.ModifiedById = types.Int64Value(int64(*v.ModifiedById))
+		} else {
+			item.ModifiedById = types.Int64Null()
+		}
+
+		itemModels = append(itemModels, item)
+	}
+
+	volumeList, listDiags := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: volumeItemModel{}.attrTypes()}, itemModels)
+	diags.Append(listDiags...)
+
+	return volumeList, diags
+}

--- a/internal/emma/workflow_template_resource.go
+++ b/internal/emma/workflow_template_resource.go
@@ -1,0 +1,666 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/internal/emma/common/convert"
+	"github.com/emma-community/terraform-provider-emma/internal/emma/common/errors"
+	"github.com/emma-community/terraform-provider-emma/internal/emma/common/state"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"net/http"
+)
+
+var _ resource.Resource = &workflowTemplateResource{}
+var _ resource.ResourceWithImportState = &workflowTemplateResource{}
+
+func NewWorkflowTemplateResource() resource.Resource {
+	return &workflowTemplateResource{}
+}
+
+type workflowTemplateResource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+type workflowTemplateResourceModel struct {
+	Id             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	Description    types.String `tfsdk:"description"`
+	ContentType    types.String `tfsdk:"content_type"`
+	Content        types.String `tfsdk:"content"`
+	Status         types.String `tfsdk:"status"`
+	ResourceType   types.String `tfsdk:"resource_type"`
+	ResourceParams types.List   `tfsdk:"resource_params"`
+	Tags           types.List   `tfsdk:"tags"`
+	ContentParams  types.List   `tfsdk:"content_params"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	CreatedByName  types.String `tfsdk:"created_by_name"`
+	CreatedById    types.String `tfsdk:"created_by_id"`
+	ModifiedAt     types.String `tfsdk:"modified_at"`
+	ModifiedByName types.String `tfsdk:"modified_by_name"`
+	ModifiedById   types.String `tfsdk:"modified_by_id"`
+	IsDeleted      types.Bool   `tfsdk:"is_deleted"`
+	IsContentValid types.Bool   `tfsdk:"is_content_valid"`
+}
+
+type workflowTemplateResourceParamModel struct {
+	Name  types.String `tfsdk:"name"`
+	Value types.String `tfsdk:"value"`
+}
+
+type workflowTemplateTagModel struct {
+	TagId types.String `tfsdk:"tag_id"`
+	Key   types.String `tfsdk:"key"`
+	Value types.String `tfsdk:"value"`
+}
+
+type workflowTemplateContentParamModel struct {
+	Name         types.String `tfsdk:"name"`
+	DefaultValue types.String `tfsdk:"default_value"`
+	Mandatory    types.Bool   `tfsdk:"mandatory"`
+}
+
+func workflowTemplateResourceParamAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":  types.StringType,
+		"value": types.StringType,
+	}
+}
+
+func workflowTemplateTagAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"tag_id": types.StringType,
+		"key":    types.StringType,
+		"value":  types.StringType,
+	}
+}
+
+func workflowTemplateContentParamAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":          types.StringType,
+		"default_value": types.StringType,
+		"mandatory":     types.BoolType,
+	}
+}
+
+func (r *workflowTemplateResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_workflow_template"
+}
+
+func (r *workflowTemplateResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "This resource manages a workflow template. A workflow template is a predefined blueprint for " +
+			"a workflow that includes shell commands and parameters. It serves as a starting point for creating " +
+			"workflows, allowing users to quickly set up and execute common processes.",
+
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description:   "ID of the workflow template",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"name": schema.StringAttribute{
+				Description: "Name of the workflow template",
+				Required:    true,
+			},
+			"description": schema.StringAttribute{
+				Description: "Description of the workflow template",
+				Optional:    true,
+				Computed:    false,
+			},
+			"content_type": schema.StringAttribute{
+				Description: "Format of the content field. Only Shell is supported for now.",
+				Required:    true,
+			},
+			"content": schema.StringAttribute{
+				Description: "Content of the workflow template. For Shell contentType, includes shell commands to execute.",
+				Required:    true,
+			},
+			"status": schema.StringAttribute{
+				Description: "Status of the workflow template. Can be PUBLISHED or UNPUBLISHED.",
+				Required:    true,
+			},
+			"resource_type": schema.StringAttribute{
+				Description: "Type of the resource, in this case COMPUTE.",
+				Required:    true,
+			},
+			"resource_params": schema.ListNestedAttribute{
+				Description: "Parameters of the resource limitation (e.g. minCpuCores, minRamSizeGb).",
+				Optional:    true,
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Description: "Name of the resource parameter (e.g. minCpuCores, minRamSizeGb, minVolumeSizeGb).",
+							Optional:    true,
+							Computed:    true,
+						},
+						"value": schema.StringAttribute{
+							Description: "Value of the resource parameter.",
+							Optional:    true,
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"tags": schema.ListNestedAttribute{
+				Description: "List of tags assigned to the workflow template.",
+				Optional:    true,
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"tag_id": schema.StringAttribute{
+							Description: "ID of the tag.",
+							Optional:    true,
+							Computed:    true,
+						},
+						"key": schema.StringAttribute{
+							Description: "Key of the tag (e.g. environment, department, project).",
+							Optional:    true,
+							Computed:    true,
+						},
+						"value": schema.StringAttribute{
+							Description: "Value of the tag (e.g. production, staging, development).",
+							Optional:    true,
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"content_params": schema.ListNestedAttribute{
+				Description: "List of parameters extracted from the content. These parameters fill in template placeholders when creating a workflow from this template.",
+				Optional:    true,
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							Description: "Name of the content parameter.",
+							Optional:    true,
+							Computed:    true,
+						},
+						"default_value": schema.StringAttribute{
+							Description: "Default value of the content parameter.",
+							Optional:    true,
+							Computed:    true,
+						},
+						"mandatory": schema.BoolAttribute{
+							Description: "Whether the content parameter is mandatory when creating a workflow.",
+							Optional:    true,
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Description:   "Date and time when the workflow template was created.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_by_name": schema.StringAttribute{
+				Description:   "Name of the user who created the workflow template.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_by_id": schema.StringAttribute{
+				Description:   "ID of the user who created the workflow template.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"modified_at": schema.StringAttribute{
+				Description: "Date and time when the workflow template was last modified.",
+				Computed:    true,
+			},
+			"modified_by_name": schema.StringAttribute{
+				Description: "Name of the user who last modified the workflow template.",
+				Computed:    true,
+			},
+			"modified_by_id": schema.StringAttribute{
+				Description: "ID of the user who last modified the workflow template.",
+				Computed:    true,
+			},
+			"is_deleted": schema.BoolAttribute{
+				Description: "Indicates whether the workflow template is deleted.",
+				Computed:    true,
+			},
+			"is_content_valid": schema.BoolAttribute{
+				Description: "Indicates whether the content of the workflow template is valid.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (r *workflowTemplateResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	r.apiClient = client.apiClient
+	r.token = client.token
+}
+
+func (r *workflowTemplateResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data workflowTemplateResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Create workflow template")
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *r.token.AccessToken)
+
+	createReq, diags := convertToWorkflowTemplateCreateRequest(ctx, data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	template, response, err := r.apiClient.WorkflowsAPI.CreateWorkflowTemplate(auth).
+		WorkflowTemplateCreate(createReq).Execute()
+
+	if err != nil {
+		statusCode := 0
+		apiError := ""
+		if response != nil {
+			statusCode = response.StatusCode
+			apiError = tools.ExtractErrorMessage(response)
+		}
+
+		resourceErr := errors.NewError("emma_workflow_template", "Create").
+			WithStatusCode(statusCode).
+			WithAPIError(apiError).
+			WithMessage(errors.MapHTTPError(statusCode, apiError)).
+			Build()
+
+		resp.Diagnostics.AddError("Client Error", resourceErr.Error())
+		return
+	}
+
+	diags = convertWorkflowTemplateToResource(ctx, &data, template)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *workflowTemplateResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data workflowTemplateResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Read workflow template")
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *r.token.AccessToken)
+
+	id, err := convert.StringToInt32(data.Id)
+	if err != nil {
+		resourceErr := errors.NewError("emma_workflow_template", "Read").
+			WithID(data.Id.ValueString()).
+			WithMessage("Invalid workflow template ID format").
+			WithCause(err).
+			Build()
+		resp.Diagnostics.AddError("Validation Error", resourceErr.Error())
+		return
+	}
+
+	template, response, err := r.apiClient.WorkflowsAPI.GetWorkflowTemplate(auth, id).Execute()
+
+	if err != nil {
+		statusCode := 0
+		apiError := ""
+		if response != nil {
+			statusCode = response.StatusCode
+			apiError = tools.ExtractErrorMessage(response)
+
+			if statusCode == http.StatusNotFound {
+				stateManager := state.NewStateManager(ctx)
+				stateManager.RemoveFromState(resp)
+				return
+			}
+		}
+
+		resourceErr := errors.NewError("emma_workflow_template", "Read").
+			WithID(data.Id.ValueString()).
+			WithStatusCode(statusCode).
+			WithAPIError(apiError).
+			WithMessage(errors.MapHTTPError(statusCode, apiError)).
+			Build()
+
+		resp.Diagnostics.AddError("Client Error", resourceErr.Error())
+		return
+	}
+
+	diags := convertWorkflowTemplateToResource(ctx, &data, template)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *workflowTemplateResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var planData workflowTemplateResourceModel
+	var stateData workflowTemplateResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Update workflow template")
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *r.token.AccessToken)
+
+	id, err := convert.StringToInt32(stateData.Id)
+	if err != nil {
+		resourceErr := errors.NewError("emma_workflow_template", "Update").
+			WithID(stateData.Id.ValueString()).
+			WithMessage("Invalid workflow template ID format").
+			WithCause(err).
+			Build()
+		resp.Diagnostics.AddError("Validation Error", resourceErr.Error())
+		return
+	}
+
+	updateReq, diags := convertToWorkflowTemplateCreateRequest(ctx, planData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	template, response, err := r.apiClient.WorkflowsAPI.UpdateWorkflowTemplate(auth, id).
+		WorkflowTemplateCreate(updateReq).Execute()
+
+	if err != nil {
+		statusCode := 0
+		apiError := ""
+		if response != nil {
+			statusCode = response.StatusCode
+			apiError = tools.ExtractErrorMessage(response)
+		}
+
+		resourceErr := errors.NewError("emma_workflow_template", "Update").
+			WithID(stateData.Id.ValueString()).
+			WithStatusCode(statusCode).
+			WithAPIError(apiError).
+			WithMessage(errors.MapHTTPError(statusCode, apiError)).
+			Build()
+
+		resp.Diagnostics.AddError("Client Error", resourceErr.Error())
+		return
+	}
+
+	diags = convertWorkflowTemplateToResource(ctx, &stateData, template)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
+}
+
+func (r *workflowTemplateResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data workflowTemplateResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "Delete workflow template")
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *r.token.AccessToken)
+
+	id, err := convert.StringToInt32(data.Id)
+	if err != nil {
+		resourceErr := errors.NewError("emma_workflow_template", "Delete").
+			WithID(data.Id.ValueString()).
+			WithMessage("Invalid workflow template ID format").
+			WithCause(err).
+			Build()
+		resp.Diagnostics.AddError("Validation Error", resourceErr.Error())
+		return
+	}
+
+	response, err := r.apiClient.WorkflowsAPI.DeleteWorkflowTemplate(auth, id).Execute()
+
+	if err != nil {
+		statusCode := 0
+		apiError := ""
+		if response != nil {
+			statusCode = response.StatusCode
+			apiError = tools.ExtractErrorMessage(response)
+		}
+
+		resourceErr := errors.NewError("emma_workflow_template", "Delete").
+			WithID(data.Id.ValueString()).
+			WithStatusCode(statusCode).
+			WithAPIError(apiError).
+			WithMessage(errors.MapHTTPError(statusCode, apiError)).
+			Build()
+
+		resp.Diagnostics.AddError("Client Error", resourceErr.Error())
+		return
+	}
+}
+
+func (r *workflowTemplateResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	tflog.Info(ctx, "Import workflow template")
+
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+
+	r.Read(ctx, resource.ReadRequest{State: resp.State, Private: resp.Private},
+		&resource.ReadResponse{State: resp.State, Private: resp.Private, Diagnostics: resp.Diagnostics})
+}
+
+func convertToWorkflowTemplateCreateRequest(ctx context.Context, data workflowTemplateResourceModel) (emmaSdk.WorkflowTemplateCreate, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	req := emmaSdk.WorkflowTemplateCreate{
+		Name:         data.Name.ValueString(),
+		ContentType:  data.ContentType.ValueString(),
+		Content:      data.Content.ValueString(),
+		Status:       data.Status.ValueString(),
+		ResourceType: data.ResourceType.ValueString(),
+	}
+
+	if !data.Description.IsNull() && !data.Description.IsUnknown() {
+		desc := data.Description.ValueString()
+		req.Description = &desc
+	}
+
+	if !data.ResourceParams.IsNull() && !data.ResourceParams.IsUnknown() {
+		var paramModels []workflowTemplateResourceParamModel
+		diags.Append(data.ResourceParams.ElementsAs(ctx, &paramModels, false)...)
+		if diags.HasError() {
+			return req, diags
+		}
+		sdkParams := make([]emmaSdk.WorkflowTemplateCreateResourceParamsInner, 0, len(paramModels))
+		for _, p := range paramModels {
+			inner := emmaSdk.WorkflowTemplateCreateResourceParamsInner{}
+			if !p.Name.IsNull() && !p.Name.IsUnknown() {
+				n := p.Name.ValueString()
+				inner.Name = &n
+			}
+			if !p.Value.IsNull() && !p.Value.IsUnknown() {
+				v := p.Value.ValueString()
+				inner.Value = &v
+			}
+			sdkParams = append(sdkParams, inner)
+		}
+		req.ResourceParams = sdkParams
+	}
+
+	if !data.Tags.IsNull() && !data.Tags.IsUnknown() {
+		var tagModels []workflowTemplateTagModel
+		diags.Append(data.Tags.ElementsAs(ctx, &tagModels, false)...)
+		if diags.HasError() {
+			return req, diags
+		}
+		sdkTags := make([]emmaSdk.WorkflowTemplateCreateTagsInner, 0, len(tagModels))
+		for _, t := range tagModels {
+			inner := emmaSdk.WorkflowTemplateCreateTagsInner{}
+			if !t.TagId.IsNull() && !t.TagId.IsUnknown() {
+				tid := t.TagId.ValueString()
+				inner.TagId = &tid
+			}
+			if !t.Key.IsNull() && !t.Key.IsUnknown() {
+				k := t.Key.ValueString()
+				inner.Key = &k
+			}
+			if !t.Value.IsNull() && !t.Value.IsUnknown() {
+				v := t.Value.ValueString()
+				inner.Value = &v
+			}
+			sdkTags = append(sdkTags, inner)
+		}
+		req.Tags = sdkTags
+	}
+
+	if !data.ContentParams.IsNull() && !data.ContentParams.IsUnknown() {
+		var cpModels []workflowTemplateContentParamModel
+		diags.Append(data.ContentParams.ElementsAs(ctx, &cpModels, false)...)
+		if diags.HasError() {
+			return req, diags
+		}
+		sdkCps := make([]emmaSdk.WorkflowTemplateCreateContentParamsInner, 0, len(cpModels))
+		for _, cp := range cpModels {
+			inner := emmaSdk.WorkflowTemplateCreateContentParamsInner{}
+			if !cp.Name.IsNull() && !cp.Name.IsUnknown() {
+				n := cp.Name.ValueString()
+				inner.Name = &n
+			}
+			if !cp.DefaultValue.IsNull() && !cp.DefaultValue.IsUnknown() {
+				dv := cp.DefaultValue.ValueString()
+				inner.DefaultValue = &dv
+			}
+			if !cp.Mandatory.IsNull() && !cp.Mandatory.IsUnknown() {
+				m := cp.Mandatory.ValueBool()
+				inner.Mandatory = &m
+			}
+			sdkCps = append(sdkCps, inner)
+		}
+		req.ContentParams = sdkCps
+	}
+
+	return req, diags
+}
+
+func convertWorkflowTemplateToResource(ctx context.Context, data *workflowTemplateResourceModel, template *emmaSdk.WorkflowTemplate) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	id := template.Id
+	data.Id = convert.Int32ToString(&id)
+	data.Name = types.StringValue(template.Name)
+	data.ContentType = types.StringValue(template.ContentType)
+	data.Content = types.StringValue(template.Content)
+	data.Status = types.StringValue(template.Status)
+	data.ResourceType = types.StringValue(template.ResourceType)
+	data.CreatedAt = types.StringValue(template.CreatedAt)
+	data.CreatedByName = types.StringValue(template.CreatedByName)
+	createdById := template.CreatedById
+	data.CreatedById = convert.Int32ToString(&createdById)
+	data.ModifiedAt = types.StringValue(template.ModifiedAt)
+	data.ModifiedByName = types.StringValue(template.ModifiedByName)
+	modifiedById := template.ModifiedById
+	data.ModifiedById = convert.Int32ToString(&modifiedById)
+	data.IsDeleted = types.BoolValue(template.IsDeleted)
+
+	if template.Description != nil {
+		data.Description = types.StringValue(*template.Description)
+	} else {
+		data.Description = types.StringNull()
+	}
+
+	if template.IsContentValid != nil {
+		data.IsContentValid = types.BoolValue(*template.IsContentValid)
+	} else {
+		data.IsContentValid = types.BoolNull()
+	}
+
+	// resource_params
+	resourceParamType := types.ObjectType{AttrTypes: workflowTemplateResourceParamAttrTypes()}
+	if len(template.ResourceParams) > 0 {
+		paramModels := make([]workflowTemplateResourceParamModel, 0, len(template.ResourceParams))
+		for _, p := range template.ResourceParams {
+			m := workflowTemplateResourceParamModel{
+				Name:  convert.StringPointerToString(p.Name),
+				Value: convert.StringPointerToString(p.Value),
+			}
+			paramModels = append(paramModels, m)
+		}
+		listVal, listDiags := types.ListValueFrom(ctx, resourceParamType, paramModels)
+		diags.Append(listDiags...)
+		data.ResourceParams = listVal
+	} else {
+		data.ResourceParams = types.ListValueMust(resourceParamType, []attr.Value{})
+	}
+
+	// tags
+	tagType := types.ObjectType{AttrTypes: workflowTemplateTagAttrTypes()}
+	if len(template.Tags) > 0 {
+		tagModels := make([]workflowTemplateTagModel, 0, len(template.Tags))
+		for _, t := range template.Tags {
+			m := workflowTemplateTagModel{
+				TagId: convert.StringPointerToString(t.TagId),
+				Key:   convert.StringPointerToString(t.Key),
+				Value: convert.StringPointerToString(t.Value),
+			}
+			tagModels = append(tagModels, m)
+		}
+		listVal, listDiags := types.ListValueFrom(ctx, tagType, tagModels)
+		diags.Append(listDiags...)
+		data.Tags = listVal
+	} else {
+		data.Tags = types.ListValueMust(tagType, []attr.Value{})
+	}
+
+	// content_params
+	contentParamType := types.ObjectType{AttrTypes: workflowTemplateContentParamAttrTypes()}
+	if len(template.ContentParams) > 0 {
+		cpModels := make([]workflowTemplateContentParamModel, 0, len(template.ContentParams))
+		for _, cp := range template.ContentParams {
+			m := workflowTemplateContentParamModel{
+				Name:         convert.StringPointerToString(cp.Name),
+				DefaultValue: convert.StringPointerToString(cp.DefaultValue),
+			}
+			if cp.Mandatory != nil {
+				m.Mandatory = types.BoolValue(*cp.Mandatory)
+			} else {
+				m.Mandatory = types.BoolNull()
+			}
+			cpModels = append(cpModels, m)
+		}
+		listVal, listDiags := types.ListValueFrom(ctx, contentParamType, cpModels)
+		diags.Append(listDiags...)
+		data.ContentParams = listVal
+	} else {
+		data.ContentParams = types.ListValueMust(contentParamType, []attr.Value{})
+	}
+
+	return diags
+}

--- a/internal/emma/workflow_template_resource.go
+++ b/internal/emma/workflow_template_resource.go
@@ -493,13 +493,14 @@ func convertToWorkflowTemplateCreateRequest(ctx context.Context, data workflowTe
 		req.Description = &desc
 	}
 
+	// Server rejects null lists ("must not be null") — default to empty slices.
+	req.ResourceParams = make([]emmaSdk.WorkflowTemplateCreateResourceParamsInner, 0)
 	if !data.ResourceParams.IsNull() && !data.ResourceParams.IsUnknown() {
 		var paramModels []workflowTemplateResourceParamModel
 		diags.Append(data.ResourceParams.ElementsAs(ctx, &paramModels, false)...)
 		if diags.HasError() {
 			return req, diags
 		}
-		sdkParams := make([]emmaSdk.WorkflowTemplateCreateResourceParamsInner, 0, len(paramModels))
 		for _, p := range paramModels {
 			inner := emmaSdk.WorkflowTemplateCreateResourceParamsInner{}
 			if !p.Name.IsNull() && !p.Name.IsUnknown() {
@@ -510,18 +511,17 @@ func convertToWorkflowTemplateCreateRequest(ctx context.Context, data workflowTe
 				v := p.Value.ValueString()
 				inner.Value = &v
 			}
-			sdkParams = append(sdkParams, inner)
+			req.ResourceParams = append(req.ResourceParams, inner)
 		}
-		req.ResourceParams = sdkParams
 	}
 
+	req.Tags = make([]emmaSdk.WorkflowTemplateCreateTagsInner, 0)
 	if !data.Tags.IsNull() && !data.Tags.IsUnknown() {
 		var tagModels []workflowTemplateTagModel
 		diags.Append(data.Tags.ElementsAs(ctx, &tagModels, false)...)
 		if diags.HasError() {
 			return req, diags
 		}
-		sdkTags := make([]emmaSdk.WorkflowTemplateCreateTagsInner, 0, len(tagModels))
 		for _, t := range tagModels {
 			inner := emmaSdk.WorkflowTemplateCreateTagsInner{}
 			if !t.TagId.IsNull() && !t.TagId.IsUnknown() {
@@ -536,18 +536,17 @@ func convertToWorkflowTemplateCreateRequest(ctx context.Context, data workflowTe
 				v := t.Value.ValueString()
 				inner.Value = &v
 			}
-			sdkTags = append(sdkTags, inner)
+			req.Tags = append(req.Tags, inner)
 		}
-		req.Tags = sdkTags
 	}
 
+	req.ContentParams = make([]emmaSdk.WorkflowTemplateCreateContentParamsInner, 0)
 	if !data.ContentParams.IsNull() && !data.ContentParams.IsUnknown() {
 		var cpModels []workflowTemplateContentParamModel
 		diags.Append(data.ContentParams.ElementsAs(ctx, &cpModels, false)...)
 		if diags.HasError() {
 			return req, diags
 		}
-		sdkCps := make([]emmaSdk.WorkflowTemplateCreateContentParamsInner, 0, len(cpModels))
 		for _, cp := range cpModels {
 			inner := emmaSdk.WorkflowTemplateCreateContentParamsInner{}
 			if !cp.Name.IsNull() && !cp.Name.IsUnknown() {
@@ -562,9 +561,8 @@ func convertToWorkflowTemplateCreateRequest(ctx context.Context, data workflowTe
 				m := cp.Mandatory.ValueBool()
 				inner.Mandatory = &m
 			}
-			sdkCps = append(sdkCps, inner)
+			req.ContentParams = append(req.ContentParams, inner)
 		}
-		req.ContentParams = sdkCps
 	}
 
 	return req, diags

--- a/internal/emma/workflow_templates_data_source.go
+++ b/internal/emma/workflow_templates_data_source.go
@@ -198,9 +198,12 @@ func (d *workflowTemplatesDataSource) Read(ctx context.Context, req datasource.R
 
 		result, response, err := apiReq.Execute()
 		if err != nil {
+			apiErr := tools.ExtractErrorMessage(response)
+			if apiErr == "" {
+				apiErr = err.Error()
+			}
 			resp.Diagnostics.AddError("Client Error",
-				fmt.Sprintf("Unable to read workflow templates, got error: %s",
-					tools.ExtractErrorMessage(response)))
+				fmt.Sprintf("Unable to read workflow templates, got error: %s", apiErr))
 			return
 		}
 

--- a/internal/emma/workflow_templates_data_source.go
+++ b/internal/emma/workflow_templates_data_source.go
@@ -1,0 +1,282 @@
+package emma
+
+import (
+	"context"
+	"fmt"
+	emmaSdk "github.com/emma-community/emma-go-sdk"
+	"github.com/emma-community/terraform-provider-emma/tools"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ datasource.DataSource = &workflowTemplatesDataSource{}
+
+func NewWorkflowTemplatesDataSource() datasource.DataSource {
+	return &workflowTemplatesDataSource{}
+}
+
+type workflowTemplatesDataSource struct {
+	apiClient *emmaSdk.APIClient
+	token     *emmaSdk.Token
+}
+
+type workflowTemplatesDataSourceModel struct {
+	NameLike          types.String `tfsdk:"name_like"`
+	Status            types.String `tfsdk:"status"`
+	WorkflowTemplates types.List   `tfsdk:"workflow_templates"`
+}
+
+type workflowTemplateItemModel struct {
+	Id             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	Description    types.String `tfsdk:"description"`
+	ContentType    types.String `tfsdk:"content_type"`
+	Content        types.String `tfsdk:"content"`
+	Status         types.String `tfsdk:"status"`
+	ResourceType   types.String `tfsdk:"resource_type"`
+	CreatedAt      types.String `tfsdk:"created_at"`
+	CreatedByName  types.String `tfsdk:"created_by_name"`
+	CreatedById    types.String `tfsdk:"created_by_id"`
+	ModifiedAt     types.String `tfsdk:"modified_at"`
+	ModifiedByName types.String `tfsdk:"modified_by_name"`
+	ModifiedById   types.String `tfsdk:"modified_by_id"`
+	IsDeleted      types.Bool   `tfsdk:"is_deleted"`
+	IsContentValid types.Bool   `tfsdk:"is_content_valid"`
+}
+
+func workflowTemplateItemAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":               types.StringType,
+		"name":             types.StringType,
+		"description":      types.StringType,
+		"content_type":     types.StringType,
+		"content":          types.StringType,
+		"status":           types.StringType,
+		"resource_type":    types.StringType,
+		"created_at":       types.StringType,
+		"created_by_name":  types.StringType,
+		"created_by_id":    types.StringType,
+		"modified_at":      types.StringType,
+		"modified_by_name": types.StringType,
+		"modified_by_id":   types.StringType,
+		"is_deleted":       types.BoolType,
+		"is_content_valid": types.BoolType,
+	}
+}
+
+func (d *workflowTemplatesDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_workflow_templates"
+}
+
+func (d *workflowTemplatesDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a list of workflow templates in the Emma platform. Optionally filter by name or status.",
+		Attributes: map[string]schema.Attribute{
+			"name_like": schema.StringAttribute{
+				Description: "Filter workflow templates by name using partial match.",
+				Optional:    true,
+			},
+			"status": schema.StringAttribute{
+				Description: "Filter workflow templates by status (e.g. PUBLISHED or UNPUBLISHED).",
+				Optional:    true,
+			},
+			"workflow_templates": schema.ListNestedAttribute{
+				Description: "List of workflow templates.",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "ID of the workflow template.",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "Name of the workflow template.",
+							Computed:    true,
+						},
+						"description": schema.StringAttribute{
+							Description: "Description of the workflow template.",
+							Computed:    true,
+						},
+						"content_type": schema.StringAttribute{
+							Description: "Format of the content field.",
+							Computed:    true,
+						},
+						"content": schema.StringAttribute{
+							Description: "Content of the workflow template.",
+							Computed:    true,
+						},
+						"status": schema.StringAttribute{
+							Description: "Status of the workflow template.",
+							Computed:    true,
+						},
+						"resource_type": schema.StringAttribute{
+							Description: "Type of the resource.",
+							Computed:    true,
+						},
+						"created_at": schema.StringAttribute{
+							Description: "Date and time when the workflow template was created.",
+							Computed:    true,
+						},
+						"created_by_name": schema.StringAttribute{
+							Description: "Name of the user who created the workflow template.",
+							Computed:    true,
+						},
+						"created_by_id": schema.StringAttribute{
+							Description: "ID of the user who created the workflow template.",
+							Computed:    true,
+						},
+						"modified_at": schema.StringAttribute{
+							Description: "Date and time when the workflow template was last modified.",
+							Computed:    true,
+						},
+						"modified_by_name": schema.StringAttribute{
+							Description: "Name of the user who last modified the workflow template.",
+							Computed:    true,
+						},
+						"modified_by_id": schema.StringAttribute{
+							Description: "ID of the user who last modified the workflow template.",
+							Computed:    true,
+						},
+						"is_deleted": schema.BoolAttribute{
+							Description: "Indicates whether the workflow template is deleted.",
+							Computed:    true,
+						},
+						"is_content_valid": schema.BoolAttribute{
+							Description: "Indicates whether the content of the workflow template is valid.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *workflowTemplatesDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.",
+				req.ProviderData))
+		return
+	}
+	d.apiClient = client.apiClient
+	d.token = client.token
+}
+
+func (d *workflowTemplatesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data workflowTemplatesDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	auth := context.WithValue(ctx, emmaSdk.ContextAccessToken, *d.token.AccessToken)
+
+	var allTemplates []emmaSdk.WorkflowTemplate
+	const pageSize int32 = 100
+	var page int32 = 0
+
+	for {
+		apiReq := d.apiClient.WorkflowsAPI.GetWorkflowTemplates(auth).
+			Page(page).
+			Size(pageSize)
+
+		if !data.NameLike.IsNull() && !data.NameLike.IsUnknown() {
+			apiReq = apiReq.NameLike(data.NameLike.ValueString())
+		}
+		if !data.Status.IsNull() && !data.Status.IsUnknown() {
+			apiReq = apiReq.Status(data.Status.ValueString())
+		}
+
+		result, response, err := apiReq.Execute()
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error",
+				fmt.Sprintf("Unable to read workflow templates, got error: %s",
+					tools.ExtractErrorMessage(response)))
+			return
+		}
+
+		if result != nil && len(result.Content) > 0 {
+			allTemplates = append(allTemplates, result.Content...)
+		}
+
+		if result == nil || result.Last == nil || *result.Last {
+			break
+		}
+		page++
+	}
+
+	templateList, diags := convertWorkflowTemplatesToList(ctx, allTemplates)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.WorkflowTemplates = templateList
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func convertWorkflowTemplatesToList(ctx context.Context, templates []emmaSdk.WorkflowTemplate) (types.List, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	itemType := types.ObjectType{AttrTypes: workflowTemplateItemAttrTypes()}
+
+	if len(templates) == 0 {
+		return types.ListValueMust(itemType, []attr.Value{}), diags
+	}
+
+	items := make([]workflowTemplateItemModel, 0, len(templates))
+	for _, t := range templates {
+		item := workflowTemplateItemModel{}
+
+		id := t.Id
+		item.Id = convertInt32ToStringValue(&id)
+		item.Name = types.StringValue(t.Name)
+		item.ContentType = types.StringValue(t.ContentType)
+		item.Content = types.StringValue(t.Content)
+		item.Status = types.StringValue(t.Status)
+		item.ResourceType = types.StringValue(t.ResourceType)
+		item.CreatedAt = types.StringValue(t.CreatedAt)
+		item.CreatedByName = types.StringValue(t.CreatedByName)
+		createdById := t.CreatedById
+		item.CreatedById = convertInt32ToStringValue(&createdById)
+		item.ModifiedAt = types.StringValue(t.ModifiedAt)
+		item.ModifiedByName = types.StringValue(t.ModifiedByName)
+		modifiedById := t.ModifiedById
+		item.ModifiedById = convertInt32ToStringValue(&modifiedById)
+		item.IsDeleted = types.BoolValue(t.IsDeleted)
+
+		if t.Description != nil {
+			item.Description = types.StringValue(*t.Description)
+		} else {
+			item.Description = types.StringNull()
+		}
+
+		if t.IsContentValid != nil {
+			item.IsContentValid = types.BoolValue(*t.IsContentValid)
+		} else {
+			item.IsContentValid = types.BoolNull()
+		}
+
+		items = append(items, item)
+	}
+
+	listVal, listDiags := types.ListValueFrom(ctx, itemType, items)
+	diags.Append(listDiags...)
+	return listVal, diags
+}
+
+func convertInt32ToStringValue(v *int32) types.String {
+	if v == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(fmt.Sprintf("%d", *v))
+}


### PR DESCRIPTION
## Summary

This PR brings the Terraform provider to **complete coverage of every user-facing Emma SDK endpoint**, plus fixes two crashes the previous release shipped.

### Coverage scoreboard (after this PR)

| Category | Before | After |
|---|---:|---:|
| Total user-facing SDK methods | 93 | 93 |
| Covered by a TF resource or data source | 59 (63%) | **74 (80%)** |
| Intentional exclusions | 19 | 19 |
| **Logical coverage (excluding exclusions)** | **80%** | **100%** |

**Intentional exclusions (documented, not implemented):**
- `RefreshToken` — provider-internal, not user-facing
- `VmActions`, `SpotActions`, `VolumeActions` — RPC-style; already abstracted into resource state transitions
- `PostMultiCloudNetworkAction` — RPC-style with no state; CLI is a better fit
- Singular by-ID lookups for `data_center` / `location` / `operating_system` / `provider` / `connectivity_center` / `spot` — already accessible through existing list+filter data sources; adding by-ID twins would duplicate the API surface

---

### 1. Bug fixes

**a) `security_group` Read panic** (`security_group_resource.go:582`)

```
panic: runtime error: index out of range [1] with length 1
```

Root cause: output slice was sized by `len(ruleOrderMap)` but the map values are loop indices into the larger state-rules slice; when duplicate keys collapsed, the surviving idx could exceed the map size → out-of-range write. Side effect: cascading "Plugin did not respond" on every concurrent data-source read because the panic killed the gRPC server.

Fix: size by `len(rules)` (always a safe index domain); skip slots the API doesn't return (deleted server-side); append server-side-added rules at the end; surface the previously-discarded `ToListValue` diagnostic.

**b) `emma_vm` / `emma_spot_instance` unknown-after-apply for accelerator fields**

```
Error: Provider returned invalid result object after apply
... unknown value for emma_vm.vm.accelerator_type_id ...
```

Root cause: `Convert{Vm,SpotInstance}ResponseToResource` left the Optional+Computed accelerator fields Unknown when the API response had no `Accelerator` object AND `planData == nil` (the Create path). Terraform requires every Optional+Computed field to have a known value after apply.

Fix: explicit `types.StringNull()` / `types.Float64Null()` in every branch where the API response does not provide a value.

---

### 2. New resource (1)

**`emma_workflow_template`** — full CRUD for workflow templates (WorkflowsAPI)
- Fields: `name`, `content_type`, `content`, `status`, `resource_type` (Required); `description`, `resource_params[]`, `tags[]`, `content_params[]` (Optional+Computed); `id`, timestamps, audit fields (Computed)
- Typed schema throughout (no JSON-string fallback) — all nested lists are shallow
- Import supported: `terraform import emma_workflow_template.foo <id>`

### 3. New data sources (15)

**Lists (9):**
- `emma_vms` — list VMs
- `emma_spots` — list spot instances
- `emma_security_groups` — list security groups
- `emma_volumes` — list volumes
- `emma_ssh_keys` — list SSH keys
- `emma_kubernetes_clusters` — list K8s clusters
- `emma_accelerator_types` — list all GPU types
- `emma_vm_configurations` — filtered VM configurations
- `emma_spot_configurations` — filtered spot configurations

**Singular lookups (1):**
- `emma_ssh_key` — single SSH key by ID

**Filtered configs (3):**
- `emma_system_volume_configs` — system volume configurations
- `emma_kuber_nodes_configs` — Kubernetes node configurations (server requires `k8s_connection_type`)
- `emma_vm_resize_configs` — available VM resize targets

**Workflows (1):**
- `emma_workflow_templates` — list workflow templates with optional `name_like` / `status` filters

**Statistics (1):**
- `emma_statistical_data` — usage/cost reports across 10 mutually-exclusive query variants (kubernetes metrics, VM analytics, resource analysis, project summary, etc.). The SDK marks this endpoint deprecated on 2026-05-13 but no replacement is published yet, so it is exposed with a `DeprecationMessage`.

### 4. Documentation

- A markdown reference page added for every new resource and data source under `docs/resources/` and `docs/data-sources/`
- GPU usage examples extended in `vm` / `spot_instance` resource docs
- Accelerator type discovery guide added to `accelerator_type` data source doc

---

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/emma/...` passes
- [x] Accelerator fields verified Optional in VM/Spot resources (non-GPU + GPU both work)
- [ ] Manual smoke test: `terraform plan` against the user's reported config no longer panics
- [ ] Manual smoke test: `terraform apply` on non-GPU + GPU mix succeeds without unknown-after-apply errors
- [ ] Smoke test new data sources against dev API
- [ ] Smoke test `emma_workflow_template` create/read/update/delete cycle against dev API