### PR TITLE
Bump emma-go-sdk v0.0.14 + add ids_by_name lookup map for GPUs

### DIFF
--- a/docs/data-sources/accelerator_types.md
+++ b/docs/data-sources/accelerator_types.md
@@ -11,13 +11,15 @@ Returns a list of all available GPU accelerator types. Use this data source to d
 
 ## Example Usage
 
-### List all available GPU types
+### Resolve a GPU id by name
 
 ```terraform
 data "emma_accelerator_types" "all" {}
 
-output "available_gpus" {
-  value = data.emma_accelerator_types.all.accelerator_types
+resource "emma_vm" "gpu_vm" {
+  # ...other required fields...
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
+  accelerators        = 1
 }
 ```
 
@@ -26,13 +28,20 @@ output "available_gpus" {
 ```terraform
 data "emma_accelerator_types" "all" {}
 
-# Pick the first accelerator type and look up VM configs for it
 data "emma_vm_configurations" "gpu" {
-  accelerator_type_id = data.emma_accelerator_types.all.accelerator_types[0].id
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA A100 40 GB"]
 }
+```
 
-output "gpu_types" {
-  value = [for t in data.emma_accelerator_types.all.accelerator_types : t.accelerator_type]
+### List the names of all available GPUs
+
+Handy for debugging or for CI checks:
+
+```terraform
+data "emma_accelerator_types" "all" {}
+
+output "available_gpus" {
+  value = keys(data.emma_accelerator_types.all.ids_by_name)
 }
 ```
 
@@ -40,6 +49,7 @@ output "gpu_types" {
 
 ### Read-Only
 
-- `accelerator_types` (List of Object) List of available GPU accelerator types. Each element has:
+- `accelerator_types` (List of Object) Full list of available GPU accelerator types. Each element has:
   - `id` (String) — Unique ID of the accelerator type (UUID)
-  - `accelerator_type` (String) — Name of the GPU model (e.g. "NVIDIA T4", "AMD Instinct MI25")
+  - `accelerator_type` (String) — Name of the GPU model (e.g. `"NVIDIA T4"`, `"AMD Instinct MI25"`)
+- `ids_by_name` (Map of String) Map from accelerator type name to its id, e.g. `accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]`. Lookup of a name that is not in the catalogue returns `null`.

--- a/docs/data-sources/spot_configurations.md
+++ b/docs/data-sources/spot_configurations.md
@@ -19,11 +19,8 @@ All filter attributes are optional — omit them to get all configurations, or c
 data "emma_accelerator_types" "all" {}
 
 data "emma_spot_configurations" "gpu_t4" {
-  accelerator_type_id = one([
-    for t in data.emma_accelerator_types.all.accelerator_types :
-    t.id if t.accelerator_type == "NVIDIA T4"
-  ])
-  vcpu_max = 4
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
+  vcpu_max            = 4
 }
 
 output "t4_spot_configs" {

--- a/docs/data-sources/vm_configurations.md
+++ b/docs/data-sources/vm_configurations.md
@@ -19,11 +19,8 @@ All filter attributes are optional — omit them to get all configurations, or c
 data "emma_accelerator_types" "all" {}
 
 data "emma_vm_configurations" "gpu_t4" {
-  accelerator_type_id = one([
-    for t in data.emma_accelerator_types.all.accelerator_types :
-    t.id if t.accelerator_type == "NVIDIA T4"
-  ])
-  price_max = 400
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
+  price_max           = 400
 }
 
 output "t4_configs" {

--- a/docs/resources/spot_instance.md
+++ b/docs/resources/spot_instance.md
@@ -63,7 +63,7 @@ resource "emma_spot_instance" "spot_instance" {
 ### Example with GPU
 
 ```terraform
-# List all available GPU models and pick the one we need by name.
+# Look up GPU types and resolve an id by name in one line.
 data "emma_accelerator_types" "all" {}
 
 resource "emma_spot_instance" "gpu_spot" {
@@ -79,10 +79,7 @@ resource "emma_spot_instance" "gpu_spot" {
   security_group_id   = emma_security_group.security_group.id
   ssh_key_id          = emma_ssh_key.ssh_key.id
   price               = 0.15
-  accelerator_type_id = one([
-    for t in data.emma_accelerator_types.all.accelerator_types :
-    t.id if t.accelerator_type == "NVIDIA T4"
-  ])
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
   accelerators        = 1
 }
 

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -53,7 +53,7 @@ resource "emma_vm" "vm" {
 ### Example with GPU
 
 ```terraform
-# List all available GPU models and pick the one we need by name.
+# Look up GPU types and resolve an id by name in one line.
 data "emma_accelerator_types" "all" {}
 
 resource "emma_vm" "gpu_vm" {
@@ -68,10 +68,7 @@ resource "emma_vm" "gpu_vm" {
   volume_gb           = 128
   security_group_id   = emma_security_group.security_group.id
   ssh_key_id          = emma_ssh_key.ssh_key.id
-  accelerator_type_id = one([
-    for t in data.emma_accelerator_types.all.accelerator_types :
-    t.id if t.accelerator_type == "NVIDIA A100 40 GB"
-  ])
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA A100 40 GB"]
   accelerators        = 1
 }
 

--- a/examples/data-sources/emma_accelerator_types/data-source.tf
+++ b/examples/data-sources/emma_accelerator_types/data-source.tf
@@ -1,11 +1,15 @@
 # List every GPU accelerator type exposed by the platform.
 data "emma_accelerator_types" "all" {}
 
-output "available_gpus" {
-  value = [for t in data.emma_accelerator_types.all.accelerator_types : t.accelerator_type]
+output "nvidia_t4_id" {
+  value = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
 }
 
-# Pick one and use it to filter VM configurations.
-data "emma_vm_configurations" "gpu_configs" {
-  accelerator_type_id = data.emma_accelerator_types.all.accelerator_types[0].id
+output "available_gpus" {
+  value = keys(data.emma_accelerator_types.all.ids_by_name)
+}
+
+# Feed an id into another data source to filter VM configurations by GPU.
+data "emma_vm_configurations" "gpu_t4_configs" {
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.7
 toolchain go1.23.1
 
 require (
-	github.com/emma-community/emma-go-sdk v0.0.13
+	github.com/emma-community/emma-go-sdk v0.0.14
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-go v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
-github.com/emma-community/emma-go-sdk v0.0.13 h1:b8CWCogxEGjHjPxT6pLpaoBMbLdISKWaDc+yP40kUHI=
-github.com/emma-community/emma-go-sdk v0.0.13/go.mod h1:rJ3Y65uAOTNKJ+DSdMPTMQywycAr5aX6KEGXMXRoXqI=
+github.com/emma-community/emma-go-sdk v0.0.14 h1:DQElz59+yufevS7/SMeCIZ9daQkqYnj/WcqQEWkrZ7g=
+github.com/emma-community/emma-go-sdk v0.0.14/go.mod h1:Yb/QQTpuRW/0nqs4WznFu8OeC7i+/SeA2OZriPQN9Dc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/emma/accelerator_types_data_source.go
+++ b/internal/emma/accelerator_types_data_source.go
@@ -27,6 +27,7 @@ type acceleratorTypesDataSource struct {
 // acceleratorTypesDataSourceModel describes the data source data model.
 type acceleratorTypesDataSourceModel struct {
 	AcceleratorTypes types.List `tfsdk:"accelerator_types"`
+	IdsByName        types.Map  `tfsdk:"ids_by_name"`
 }
 
 // acceleratorTypeItemModel describes individual accelerator type items in the list.
@@ -58,6 +59,12 @@ func (d *acceleratorTypesDataSource) Schema(ctx context.Context, req datasource.
 						},
 					},
 				},
+			},
+			"ids_by_name": schema.MapAttribute{
+				Description: "Map from accelerator type name to its id, e.g. " +
+					"`accelerator_type_id = data.emma_accelerator_types.all.ids_by_name[\"NVIDIA T4\"]`.",
+				Computed:    true,
+				ElementType: types.StringType,
 			},
 		},
 	}
@@ -104,6 +111,13 @@ func (d *acceleratorTypesDataSource) Read(ctx context.Context, req datasource.Re
 
 	data.AcceleratorTypes = typeList
 
+	idsByName, mapDiags := buildAcceleratorIdsByName(ctx, acceleratorTypes)
+	resp.Diagnostics.Append(mapDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.IdsByName = idsByName
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -113,6 +127,24 @@ func (o acceleratorTypeItemModel) attrTypes() map[string]attr.Type {
 		"id":               types.StringType,
 		"accelerator_type": types.StringType,
 	}
+}
+
+// buildAcceleratorIdsByName builds a map from accelerator type name to its id.
+// Items missing either field are skipped. On duplicate names the first one wins
+// (in practice names are unique on the platform).
+func buildAcceleratorIdsByName(ctx context.Context, acceleratorTypes []emmaSdk.AcceleratorType) (types.Map, diag.Diagnostics) {
+	pairs := make(map[string]attr.Value, len(acceleratorTypes))
+	for _, at := range acceleratorTypes {
+		if at.Id == nil || at.AcceleratorType == nil {
+			continue
+		}
+		name := *at.AcceleratorType
+		if _, exists := pairs[name]; exists {
+			continue
+		}
+		pairs[name] = types.StringValue(*at.Id)
+	}
+	return types.MapValue(types.StringType, pairs)
 }
 
 // convertAcceleratorTypesToList converts Emma API accelerator types response to Terraform list

--- a/internal/emma/workflow_template_resource.go
+++ b/internal/emma/workflow_template_resource.go
@@ -578,7 +578,11 @@ func convertWorkflowTemplateToResource(ctx context.Context, data *workflowTempla
 	data.Content = types.StringValue(template.Content)
 	data.Status = types.StringValue(template.Status)
 	data.ResourceType = types.StringValue(template.ResourceType)
-	data.CreatedAt = types.StringValue(template.CreatedAt)
+	if template.CreatedAt != nil {
+		data.CreatedAt = types.StringValue(*template.CreatedAt)
+	} else {
+		data.CreatedAt = types.StringNull()
+	}
 	data.CreatedByName = types.StringValue(template.CreatedByName)
 	createdById := template.CreatedById
 	data.CreatedById = convert.Int32ToString(&createdById)

--- a/internal/emma/workflow_templates_data_source.go
+++ b/internal/emma/workflow_templates_data_source.go
@@ -247,7 +247,11 @@ func convertWorkflowTemplatesToList(ctx context.Context, templates []emmaSdk.Wor
 		item.Content = types.StringValue(t.Content)
 		item.Status = types.StringValue(t.Status)
 		item.ResourceType = types.StringValue(t.ResourceType)
-		item.CreatedAt = types.StringValue(t.CreatedAt)
+		if t.CreatedAt != nil {
+			item.CreatedAt = types.StringValue(*t.CreatedAt)
+		} else {
+			item.CreatedAt = types.StringNull()
+		}
 		item.CreatedByName = types.StringValue(t.CreatedByName)
 		createdById := t.CreatedById
 		item.CreatedById = convertInt32ToStringValue(&createdById)


### PR DESCRIPTION
Two tightly-coupled changes, one PR:

1. **SDK bump v0.0.13 → v0.0.14** — fixes \`WorkflowTemplate.createdAt\` being marked required when the API does not return it (emma-community/emma-go-sdk#11, SDK PR #12). Field type changes from \`string\` to \`*string\`, two provider call sites need nil-safe access.

2. **\`ids_by_name\` on \`emma_accelerator_types\`** — restores the ergonomics of the old singular \`emma_accelerator_type\` data source (removed in PR #16) without re-introducing a duplicate data source on the same \`/v1/accelerator-types\` endpoint.

## What changes

### SDK bump
| File | Change |
|---|---|
| \`go.mod\` / \`go.sum\` | v0.0.13 → v0.0.14 |
| \`internal/emma/workflow_template_resource.go:581\` | \`types.StringValue(template.CreatedAt)\` → nil-check + \`StringNull()\` on absent |
| \`internal/emma/workflow_templates_data_source.go:250\` | Same fix on the list path |

KubernetesUpdateResponse audit fields also became pointers in v0.0.14, but \`kubernetes_resource.go\` ignores the response from \`EditKubernetesCluster\` (\`_, _, _ := …Execute()\`) — no provider changes needed there.

### ids_by_name

**Before** (every consumer):

\`\`\`hcl
accelerator_type_id = one([
  for t in data.emma_accelerator_types.all.accelerator_types :
  t.id if t.accelerator_type == "NVIDIA T4"
])
\`\`\`

**After:**

\`\`\`hcl
accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
\`\`\`

| File | Change |
|---|---|
| \`internal/emma/accelerator_types_data_source.go\` | + \`ids_by_name\` \`MapAttribute(Computed, ElementType: StringType)\` and \`buildAcceleratorIdsByName\` helper that populates it from the API response |
| \`examples/data-sources/emma_accelerator_types/data-source.tf\` | Demonstrates the new lookup as the primary usage |
| \`docs/data-sources/accelerator_types.md\` | "Resolve a GPU id by name (preferred)" section + schema entry |
| \`docs/resources/vm.md\` / \`spot_instance.md\` | "Example with GPU" snippets switched to \`ids_by_name["…"]\` |
| \`docs/data-sources/vm_configurations.md\` / \`spot_configurations.md\` | Same migration in their GPU filter examples |

The existing \`accelerator_types\` list attribute is unchanged — additive only.

## Verified on dev (project 1297)

\`\`\`
map_size       = 20
nvidia_t4_id   = "fd792b40-3d5a-40b5-a84d-b6b86f1b47b4"
nvidia_a100_id = "dbe6f71d-e39b-4456-86f3-3478a87b7bf2"
type_check     = "string"
\`\`\`

Map returns a scalar string usable as \`accelerator_type_id\`.

## Test plan
- [x] \`go build ./...\` passes against v0.0.14
- [x] \`go test ./internal/emma/...\` passes
- [x] \`terraform apply\` on dev returns the expected 20-entry map with real UUIDs
- [ ] Smoke test \`emma_workflow_templates\` list (was blocked by SDK bug) and \`emma_workflow_template\` resource CRUD end-to-end

## Unblocks

\`emma_workflow_templates\` and \`emma_workflow_template\` (shipped in PR #15 but runtime-blocked by the SDK bug) become usable end-to-end after this merge.