### PR TITLE
Add ids_by_name lookup map to emma_accelerator_types (no more for-expression)

### DIFF
--- a/docs/data-sources/accelerator_types.md
+++ b/docs/data-sources/accelerator_types.md
@@ -11,13 +11,17 @@ Returns a list of all available GPU accelerator types. Use this data source to d
 
 ## Example Usage
 
-### List all available GPU types
+### Resolve a GPU id by name (preferred)
+
+Use the computed `ids_by_name` map to wire a GPU into a VM or spot resource with a single lookup, no `for`-expression required.
 
 ```terraform
 data "emma_accelerator_types" "all" {}
 
-output "available_gpus" {
-  value = data.emma_accelerator_types.all.accelerator_types
+resource "emma_vm" "gpu_vm" {
+  # ...other required fields...
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
+  accelerators        = 1
 }
 ```
 
@@ -26,13 +30,20 @@ output "available_gpus" {
 ```terraform
 data "emma_accelerator_types" "all" {}
 
-# Pick the first accelerator type and look up VM configs for it
 data "emma_vm_configurations" "gpu" {
-  accelerator_type_id = data.emma_accelerator_types.all.accelerator_types[0].id
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA A100 40 GB"]
 }
+```
 
-output "gpu_types" {
-  value = [for t in data.emma_accelerator_types.all.accelerator_types : t.accelerator_type]
+### List the names of all available GPUs
+
+Handy for debugging or for CI checks:
+
+```terraform
+data "emma_accelerator_types" "all" {}
+
+output "available_gpus" {
+  value = keys(data.emma_accelerator_types.all.ids_by_name)
 }
 ```
 
@@ -40,6 +51,7 @@ output "gpu_types" {
 
 ### Read-Only
 
-- `accelerator_types` (List of Object) List of available GPU accelerator types. Each element has:
+- `accelerator_types` (List of Object) Full list of available GPU accelerator types. Each element has:
   - `id` (String) — Unique ID of the accelerator type (UUID)
-  - `accelerator_type` (String) — Name of the GPU model (e.g. "NVIDIA T4", "AMD Instinct MI25")
+  - `accelerator_type` (String) — Name of the GPU model (e.g. `"NVIDIA T4"`, `"AMD Instinct MI25"`)
+- `ids_by_name` (Map of String) Convenience lookup: map from accelerator type name to its id. Use to wire a GPU into a VM or spot resource without a `for`-expression, e.g. `accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]`. Names are unique on the platform; if a name is not present in the catalogue, the map lookup returns `null`.

--- a/docs/data-sources/spot_configurations.md
+++ b/docs/data-sources/spot_configurations.md
@@ -19,11 +19,8 @@ All filter attributes are optional — omit them to get all configurations, or c
 data "emma_accelerator_types" "all" {}
 
 data "emma_spot_configurations" "gpu_t4" {
-  accelerator_type_id = one([
-    for t in data.emma_accelerator_types.all.accelerator_types :
-    t.id if t.accelerator_type == "NVIDIA T4"
-  ])
-  vcpu_max = 4
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
+  vcpu_max            = 4
 }
 
 output "t4_spot_configs" {

--- a/docs/data-sources/vm_configurations.md
+++ b/docs/data-sources/vm_configurations.md
@@ -19,11 +19,8 @@ All filter attributes are optional — omit them to get all configurations, or c
 data "emma_accelerator_types" "all" {}
 
 data "emma_vm_configurations" "gpu_t4" {
-  accelerator_type_id = one([
-    for t in data.emma_accelerator_types.all.accelerator_types :
-    t.id if t.accelerator_type == "NVIDIA T4"
-  ])
-  price_max = 400
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
+  price_max           = 400
 }
 
 output "t4_configs" {

--- a/docs/resources/spot_instance.md
+++ b/docs/resources/spot_instance.md
@@ -63,7 +63,7 @@ resource "emma_spot_instance" "spot_instance" {
 ### Example with GPU
 
 ```terraform
-# List all available GPU models and pick the one we need by name.
+# Look up GPU types and resolve an id by name in one line.
 data "emma_accelerator_types" "all" {}
 
 resource "emma_spot_instance" "gpu_spot" {
@@ -79,10 +79,7 @@ resource "emma_spot_instance" "gpu_spot" {
   security_group_id   = emma_security_group.security_group.id
   ssh_key_id          = emma_ssh_key.ssh_key.id
   price               = 0.15
-  accelerator_type_id = one([
-    for t in data.emma_accelerator_types.all.accelerator_types :
-    t.id if t.accelerator_type == "NVIDIA T4"
-  ])
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
   accelerators        = 1
 }
 

--- a/docs/resources/vm.md
+++ b/docs/resources/vm.md
@@ -53,7 +53,7 @@ resource "emma_vm" "vm" {
 ### Example with GPU
 
 ```terraform
-# List all available GPU models and pick the one we need by name.
+# Look up GPU types and resolve an id by name in one line.
 data "emma_accelerator_types" "all" {}
 
 resource "emma_vm" "gpu_vm" {
@@ -68,10 +68,7 @@ resource "emma_vm" "gpu_vm" {
   volume_gb           = 128
   security_group_id   = emma_security_group.security_group.id
   ssh_key_id          = emma_ssh_key.ssh_key.id
-  accelerator_type_id = one([
-    for t in data.emma_accelerator_types.all.accelerator_types :
-    t.id if t.accelerator_type == "NVIDIA A100 40 GB"
-  ])
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA A100 40 GB"]
   accelerators        = 1
 }
 

--- a/examples/data-sources/emma_accelerator_types/data-source.tf
+++ b/examples/data-sources/emma_accelerator_types/data-source.tf
@@ -1,11 +1,19 @@
 # List every GPU accelerator type exposed by the platform.
 data "emma_accelerator_types" "all" {}
 
-output "available_gpus" {
-  value = [for t in data.emma_accelerator_types.all.accelerator_types : t.accelerator_type]
+# Convenience map: name -> id. Resolves a GPU name directly without a
+# for-expression. Preferred way to wire an id into emma_vm / emma_spot_instance.
+output "nvidia_t4_id" {
+  value = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
 }
 
-# Pick one and use it to filter VM configurations.
-data "emma_vm_configurations" "gpu_configs" {
-  accelerator_type_id = data.emma_accelerator_types.all.accelerator_types[0].id
+# Plain list of names — useful for `terraform plan`/CI sanity checks or to log
+# what is available on the platform right now.
+output "available_gpus" {
+  value = keys(data.emma_accelerator_types.all.ids_by_name)
+}
+
+# Feed an id into another data source to filter VM configurations by GPU.
+data "emma_vm_configurations" "gpu_t4_configs" {
+  accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
 }

--- a/internal/emma/accelerator_types_data_source.go
+++ b/internal/emma/accelerator_types_data_source.go
@@ -27,6 +27,7 @@ type acceleratorTypesDataSource struct {
 // acceleratorTypesDataSourceModel describes the data source data model.
 type acceleratorTypesDataSourceModel struct {
 	AcceleratorTypes types.List `tfsdk:"accelerator_types"`
+	IdsByName        types.Map  `tfsdk:"ids_by_name"`
 }
 
 // acceleratorTypeItemModel describes individual accelerator type items in the list.
@@ -58,6 +59,13 @@ func (d *acceleratorTypesDataSource) Schema(ctx context.Context, req datasource.
 						},
 					},
 				},
+			},
+			"ids_by_name": schema.MapAttribute{
+				Description: "Convenience lookup: map from accelerator type name to its id. " +
+					"Use to wire a GPU into a VM or spot resource without a for-expression, " +
+					"e.g. `accelerator_type_id = data.emma_accelerator_types.all.ids_by_name[\"NVIDIA T4\"]`.",
+				Computed:    true,
+				ElementType: types.StringType,
 			},
 		},
 	}
@@ -104,6 +112,13 @@ func (d *acceleratorTypesDataSource) Read(ctx context.Context, req datasource.Re
 
 	data.AcceleratorTypes = typeList
 
+	idsByName, mapDiags := buildAcceleratorIdsByName(ctx, acceleratorTypes)
+	resp.Diagnostics.Append(mapDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.IdsByName = idsByName
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -113,6 +128,24 @@ func (o acceleratorTypeItemModel) attrTypes() map[string]attr.Type {
 		"id":               types.StringType,
 		"accelerator_type": types.StringType,
 	}
+}
+
+// buildAcceleratorIdsByName builds a map from accelerator type name to its id.
+// Items missing either field are skipped. On duplicate names the first one wins
+// (in practice names are unique on the platform).
+func buildAcceleratorIdsByName(ctx context.Context, acceleratorTypes []emmaSdk.AcceleratorType) (types.Map, diag.Diagnostics) {
+	pairs := make(map[string]attr.Value, len(acceleratorTypes))
+	for _, at := range acceleratorTypes {
+		if at.Id == nil || at.AcceleratorType == nil {
+			continue
+		}
+		name := *at.AcceleratorType
+		if _, exists := pairs[name]; exists {
+			continue
+		}
+		pairs[name] = types.StringValue(*at.Id)
+	}
+	return types.MapValue(types.StringType, pairs)
 }
 
 // convertAcceleratorTypesToList converts Emma API accelerator types response to Terraform list


### PR DESCRIPTION
Looking up a GPU id by name on `emma_accelerator_types` currently requires an inline for-expression in every consumer:

    accelerator_type_id = one([
      for t in data.emma_accelerator_types.all.accelerator_types :
      t.id if t.accelerator_type == "NVIDIA T4"
    ])

This PR adds a computed `ids_by_name` map of name → id to the same data source, turning the lookup into a one-liner:

    accelerator_type_id = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]

Matches the ergonomics of the old singular `emma_accelerator_type` data source (removed in PR #16) — but without a duplicate data source on the same `/v1/accelerator-types` endpoint.

## What changed

| File | Change |
|---|---|
| `internal/emma/accelerator_types_data_source.go` | + `ids_by_name` `MapAttribute(Computed, ElementType: StringType)` and a `buildAcceleratorIdsByName` helper that populates it from the API response. First-write wins on duplicate names (names are unique on the platform in practice). |
| `examples/data-sources/emma_accelerator_types/data-source.tf` | Demonstrates the new lookup as the primary usage. |
| `docs/data-sources/accelerator_types.md` | "Resolve a GPU id by name (preferred)" section + schema entry. |
| `docs/resources/vm.md` / `spot_instance.md` | `Example with GPU` snippets switched to `ids_by_name["…"]`. |
| `docs/data-sources/vm_configurations.md` / `spot_configurations.md` | Same migration in their GPU filter examples. |

## Verified on dev (project 1297)

```
map_size       = 20
nvidia_t4_id   = "fd792b40-3d5a-40b5-a84d-b6b86f1b47b4"
nvidia_a100_id = "dbe6f71d-e39b-4456-86f3-3478a87b7bf2"
type_check     = "string"
```

Returns a scalar string suitable for direct use as `accelerator_type_id`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/emma/...` passes
- [x] `terraform apply` against dev returns the expected map (20 items, real UUIDs)
- [ ] Optional: smoke `terraform apply` of an `emma_vm` using `ids_by_name["NVIDIA A100 40 GB"]` end-to-end

## Backward compatibility

- The existing `accelerator_types` list attribute is unchanged — old code using `for t in … : t.id if t.accelerator_type == …` continues to work.
- `ids_by_name` is a new computed attribute, additive.
- No SDK changes — built entirely from existing `GetAcceleratorTypes` response.