### PR TITLE
Add full list and map output examples for accelerator_types

### DIFF
--- a/docs/data-sources/accelerator_types.md
+++ b/docs/data-sources/accelerator_types.md
@@ -45,6 +45,30 @@ output "available_gpus" {
 }
 ```
 
+### List all GPUs with full details
+
+Output the complete list of accelerator types (id + name):
+
+```terraform
+data "emma_accelerator_types" "all" {}
+
+output "available_gpus" {
+  value = data.emma_accelerator_types.all.accelerator_types
+}
+```
+
+### List all GPUs as a name-to-id map
+
+Output the full `ids_by_name` map:
+
+```terraform
+data "emma_accelerator_types" "all" {}
+
+output "available_gpus" {
+  value = data.emma_accelerator_types.all.ids_by_name
+}
+```
+
 ## Schema
 
 ### Read-Only

--- a/examples/data-sources/emma_accelerator_types/data-source.tf
+++ b/examples/data-sources/emma_accelerator_types/data-source.tf
@@ -5,8 +5,16 @@ output "nvidia_t4_id" {
   value = data.emma_accelerator_types.all.ids_by_name["NVIDIA T4"]
 }
 
-output "available_gpus" {
+output "available_gpu_names" {
   value = keys(data.emma_accelerator_types.all.ids_by_name)
+}
+
+output "available_gpus" {
+  value = data.emma_accelerator_types.all.accelerator_types
+}
+
+output "available_gpus_map" {
+  value = data.emma_accelerator_types.all.ids_by_name
 }
 
 # Feed an id into another data source to filter VM configurations by GPU.


### PR DESCRIPTION
## Summary
- Add two new examples to `accelerator_types` data source docs: output full `accelerator_types` list and `ids_by_name` map
- Update example `.tf` file with all three output variants (names only, full list, name-to-id map)

## Test plan
- [ ] Docs render correctly on Terraform Registry